### PR TITLE
Feature: Convert to Bun, and properly configure exports, prettier, and eslint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,28 +4,31 @@
 name: Testing
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
-  build:
+    build:
+        runs-on: ubuntu-latest
 
-    runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [16.x, 18.x, 23.x]
+                # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
-    strategy:
-      matrix:
-        node-version: [16.x, 18.x, 23.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+            - name: Install Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: "latest"
+            - run: npm ci
+            - run: npm run build --if-present
+            - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ devenv.local.yaml
 
 # pre-commit
 .pre-commit-config.yaml
+docs/*

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test.ts
 dist/
 doc/
 types/
+tsconfig.tsbuildinfo
 
 # NPM
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ devenv.local.yaml
 
 # pre-commit
 .pre-commit-config.yaml
+docs/
 docs/*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+    "printWidth": 80,
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": false,
+    "trailingComma": "all",
+    "bracketSpacing": true,
+    "arrowParens": "always",
+    "proseWrap": "preserve"
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Full documentation can be found [here](https://makeshiftartist.github.io/iFunny.
 
 ## Authors
 
--   [@MakeShiftArtist](https://www.github.com/MakeShiftArtist)
+- [@MakeShiftArtist](https://www.github.com/MakeShiftArtist)
 
 ## Quick Start Guide
 
@@ -87,22 +87,22 @@ Install iFunny.ts
 import iFunnyClient from "ifunny.ts";
 
 const client = new iFunnyClient({
-	basic: process.env.BASIC,
-	bearer: process.env.BEARER,
+    basic: process.env.BASIC,
+    bearer: process.env.BEARER,
 });
 
 async function main() {
-	const user = client.users.byNick("iFunnyChef");
-	if (user) {
-		console.log(user.id);
-		await user.suscribe();
-	}
+    const user = client.users.byNick("iFunnyChef");
+    if (user) {
+        console.log(user.id);
+        await user.suscribe();
+    }
 }
 ```
 
 ## Links
 
--   [Documentation](https://makeshiftartist.github.io/iFunny.ts/)
--   [npm](https://www.npmjs.com/package/ifunny.ts)
--   [GitHub](https://github.com/ifunny-co/iFunny.ts)
--   [iFunny API Discord Server](https://discord.gg/Wvkycj5xGW)
+- [Documentation](https://makeshiftartist.github.io/iFunny.ts/)
+- [npm](https://www.npmjs.com/package/ifunny.ts)
+- [GitHub](https://github.com/ifunny-co/iFunny.ts)
+- [iFunny API Discord Server](https://discord.gg/Wvkycj5xGW)

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,534 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "ifunny.ts",
+      "dependencies": {
+        "@ifunny/ifunny-api-types": "1.0.4",
+        "axios": "1.13.2",
+        "eventemitter3": "5.0.1",
+        "node-ts-cache": "^4.4.0",
+        "node-ts-cache-storage-memory": "^4.4.0",
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.2",
+        "@eslint/json": "^0.14.0",
+        "@types/node": "25.0.2",
+        "@types/readline-sync": "^1.4.8",
+        "@typescript-eslint/eslint-plugin": "^8.49.0",
+        "@typescript-eslint/parser": "^8.49.0",
+        "auto-changelog": "2.5.0",
+        "bun-types": "^1.3.4",
+        "dotenv": "^17.2.3",
+        "eslint": "^9.39.2",
+        "gh-pages": "6.3.0",
+        "globals": "^16.5.0",
+        "jiti": "^2.6.1",
+        "prettier": "^3.7.4",
+        "readline-sync": "^1.4.10",
+        "ts-node": "10.9.2",
+        "typedoc": "^0.28.15",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.49.0",
+      },
+    },
+  },
+  "packages": {
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.1", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.3", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ=="],
+
+    "@eslint/js": ["@eslint/js@9.39.2", "", {}, "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA=="],
+
+    "@eslint/json": ["@eslint/json@0.14.0", "", { "dependencies": { "@eslint/core": "^0.17.0", "@eslint/plugin-kit": "^0.4.1", "@humanwhocodes/momoa": "^3.3.10", "natural-compare": "^1.4.0" } }, "sha512-rvR/EZtvUG3p9uqrSmcDJPYSH7atmWr0RnFWN6m917MAPx82+zQgPUmDu0whPFG6XTyM0vB/hR6c1Q63OaYtCQ=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.20.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.20.0", "@shikijs/langs": "^3.20.0", "@shikijs/themes": "^3.20.0", "@shikijs/types": "^3.20.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-Wa57i+bMpK6PGJZ1f2myxo3iO+K/kZikcyvH8NIqNNZhQUbDav7V9LQmWOXhf946mz5c1NZ19WMsGYiDKTryzQ=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/momoa": ["@humanwhocodes/momoa@3.3.10", "", {}, "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@ifunny/ifunny-api-types": ["@ifunny/ifunny-api-types@1.0.4", "", {}, "sha512-sIgDo+Ml8VAQ0a4Psl4HYP4Bo6Z92DCNNNHxO3IKQPvDZDrUAmnIQeikJifMLIU/Atd2VSWgeBH9fjR/qgg86g=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.1", "", {}, "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.4.15", "", {}, "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.20.0", "", { "dependencies": { "@shikijs/types": "3.20.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-Yx3gy7xLzM0ZOjqoxciHjA7dAt5tyzJE3L4uQoM83agahy+PlW244XJSrmJRSBvGYELDhYXPacD4R/cauV5bzQ=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.20.0", "", { "dependencies": { "@shikijs/types": "3.20.0" } }, "sha512-le+bssCxcSHrygCWuOrYJHvjus6zhQ2K7q/0mgjiffRbkhM4o1EWu2m+29l0yEsHDbWaWPNnDUTRVVBvBBeKaA=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.20.0", "", { "dependencies": { "@shikijs/types": "3.20.0" } }, "sha512-U1NSU7Sl26Q7ErRvJUouArxfM2euWqq1xaSrbqMu2iqa+tSp0D1Yah8216sDYbdDHw4C8b75UpE65eWorm2erQ=="],
+
+    "@shikijs/types": ["@shikijs/types@3.20.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-lhYAATn10nkZcBQ0BlzSbJA3wcmL5MXUUF8d2Zzon6saZDlToKaiRX60n2+ZaHJCmXEcZRWNzn+k9vplr8Jhsw=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@tsconfig/node10": ["@tsconfig/node10@1.0.9", "", {}, "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="],
+
+    "@tsconfig/node12": ["@tsconfig/node12@1.0.11", "", {}, "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="],
+
+    "@tsconfig/node14": ["@tsconfig/node14@1.0.3", "", {}, "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="],
+
+    "@tsconfig/node16": ["@tsconfig/node16@1.0.3", "", {}, "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@25.0.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA=="],
+
+    "@types/readline-sync": ["@types/readline-sync@1.4.8", "", {}, "sha512-BL7xOf0yKLA6baAX6MMOnYkoflUyj/c7y3pqMRfU0va7XlwHAOTOIo4x55P/qLfMsuaYdJJKubToLqRVmRtRZA=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.49.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/type-utils": "8.49.0", "@typescript-eslint/utils": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.49.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.49.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/types": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.49.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.49.0", "@typescript-eslint/types": "^8.49.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.49.0", "", { "dependencies": { "@typescript-eslint/types": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0" } }, "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.49.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.49.0", "", { "dependencies": { "@typescript-eslint/types": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0", "@typescript-eslint/utils": "8.49.0", "debug": "^4.3.4", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.49.0", "", {}, "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.49.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.49.0", "@typescript-eslint/tsconfig-utils": "8.49.0", "@typescript-eslint/types": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "debug": "^4.3.4", "minimatch": "^9.0.4", "semver": "^7.6.0", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.49.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/types": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.49.0", "", { "dependencies": { "@typescript-eslint/types": "8.49.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA=="],
+
+    "acorn": ["acorn@8.14.1", "", { "bin": "bin/acorn" }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "acorn-walk": ["acorn-walk@8.2.0", "", {}, "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="],
+
+    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "async": ["async@3.2.4", "", {}, "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "auto-changelog": ["auto-changelog@2.5.0", "", { "dependencies": { "commander": "^7.2.0", "handlebars": "^4.7.7", "import-cwd": "^3.0.0", "node-fetch": "^2.6.1", "parse-github-url": "^1.0.3", "semver": "^7.3.5" }, "bin": "src/index.js" }, "sha512-UTnLjT7I9U2U/xkCUH5buDlp8C7g0SGChfib+iDrJkamcj5kaMqNKHNfbKJw1kthJUq8sUo3i3q2S6FzO/l/wA=="],
+
+    "axios": ["axios@1.13.2", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
+
+    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "denque": ["denque@1.5.1", "", {}, "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="],
+
+    "diff": ["diff@4.0.2", "", {}, "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="],
+
+    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "email-addresses": ["email-addresses@5.0.0", "", {}, "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.39.2", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "filename-reserved-regex": ["filename-reserved-regex@2.0.0", "", {}, "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ=="],
+
+    "filenamify": ["filenamify@4.3.0", "", { "dependencies": { "filename-reserved-regex": "^2.0.0", "strip-outer": "^1.0.1", "trim-repeated": "^1.0.0" } }, "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-cache-dir": ["find-cache-dir@3.3.2", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^3.0.2", "pkg-dir": "^4.1.0" } }, "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+
+    "follow-redirects": ["follow-redirects@1.15.6", "", {}, "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="],
+
+    "form-data": ["form-data@4.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow=="],
+
+    "fs-extra": ["fs-extra@11.3.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gh-pages": ["gh-pages@6.3.0", "", { "dependencies": { "async": "^3.2.4", "commander": "^13.0.0", "email-addresses": "^5.0.0", "filenamify": "^4.3.0", "find-cache-dir": "^3.3.1", "fs-extra": "^11.1.1", "globby": "^11.1.0" }, "bin": { "gh-pages": "bin/gh-pages.js", "gh-pages-clean": "bin/gh-pages-clean.js" } }, "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
+
+    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "handlebars": ["handlebars@4.7.7", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.0", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": "bin/handlebars" }, "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "import-cwd": ["import-cwd@3.0.0", "", { "dependencies": { "import-from": "^3.0.0" } }, "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "import-from": ["import-from@3.0.0", "", { "dependencies": { "resolve-from": "^5.0.0" } }, "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
+
+    "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
+
+    "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
+
+    "markdown-it": ["markdown-it@14.1.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "node-fetch": ["node-fetch@2.6.9", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg=="],
+
+    "node-ts-cache": ["node-ts-cache@4.4.0", "", { "dependencies": { "bluebird": "3.7.2", "debug": "^4.3.2", "redis": "^3.1.2" } }, "sha512-ZULcxpzyFfgpOd33PHjwhPz4fkWSfyrwa9sq1j4jyOm+PaBpQDIzB3m5HRiSKdgEBtQhP3g6hX44dnMjnoHiPA=="],
+
+    "node-ts-cache-storage-memory": ["node-ts-cache-storage-memory@4.4.0", "", { "dependencies": { "debug": "^4.3.2", "node-ts-cache": "^4.4.0" } }, "sha512-eG8tFF4C1/RBmx52cS/dEu63l+Cn+Z6mz16nuTJwNyvtvDHWjsKKM3hg77PA7ddgf2ztaCyen8ZMQnLy191S4g=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-github-url": ["parse-github-url@1.0.3", "", { "bin": "cli.js" }, "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.7.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "readline-sync": ["readline-sync@1.4.10", "", {}, "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="],
+
+    "redis": ["redis@3.1.2", "", { "dependencies": { "denque": "^1.5.0", "redis-commands": "^1.7.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0" } }, "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw=="],
+
+    "redis-commands": ["redis-commands@1.7.0", "", {}, "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="],
+
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "semver": ["semver@7.7.1", "", { "bin": "bin/semver.js" }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "strip-outer": ["strip-outer@1.0.1", "", { "dependencies": { "escape-string-regexp": "^1.0.2" } }, "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "trim-repeated": ["trim-repeated@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.2" } }, "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg=="],
+
+    "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
+
+    "ts-node": ["ts-node@10.9.2", "", { "dependencies": { "@cspotcode/source-map-support": "^0.8.0", "@tsconfig/node10": "^1.0.7", "@tsconfig/node12": "^1.0.7", "@tsconfig/node14": "^1.0.0", "@tsconfig/node16": "^1.0.2", "acorn": "^8.4.1", "acorn-walk": "^8.1.1", "arg": "^4.1.0", "create-require": "^1.1.0", "diff": "^4.0.1", "make-error": "^1.1.1", "v8-compile-cache-lib": "^3.0.1", "yn": "3.1.1" }, "peerDependencies": { "@swc/core": ">=1.2.50", "@swc/wasm": ">=1.2.50", "@types/node": "*", "typescript": ">=2.7" }, "optionalPeers": ["@swc/core", "@swc/wasm"], "bin": { "ts-node": "dist/bin.js", "ts-node-cwd": "dist/bin-cwd.js", "ts-node-esm": "dist/bin-esm.js", "ts-node-script": "dist/bin-script.js", "ts-node-transpile-only": "dist/bin-transpile.js", "ts-script": "dist/bin-script-deprecated.js" } }, "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typedoc": ["typedoc@0.28.15", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.17.0", "lunr": "^2.3.9", "markdown-it": "^14.1.0", "minimatch": "^9.0.5", "yaml": "^2.8.1" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-mw2/2vTL7MlT+BVo43lOsufkkd2CJO4zeOSuWQQsiXoV2VuEn7f6IZp2jsUDPmBMABpgR0R5jlcJ2OGEFYmkyg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.49.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.49.0", "@typescript-eslint/parser": "8.49.0", "@typescript-eslint/typescript-estree": "8.49.0", "@typescript-eslint/utils": "8.49.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
+
+    "uglify-js": ["uglify-js@3.17.4", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "yn": ["yn@3.1.1", "", {}, "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "espree/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "gh-pages/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "make-dir/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "strip-outer/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "trim-repeated/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "typedoc/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "typedoc/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+  }
+}

--- a/devenv.lock
+++ b/devenv.lock
@@ -74,16 +74,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764580874,
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "dcf61356c3ab25f1362b4a4428a6d871e84f1d1d",
+        "lastModified": 1765457389,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f997fa0f94fb1ce55bccb97f60d41412ae8fde4c",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },

--- a/devenv.nix
+++ b/devenv.nix
@@ -12,16 +12,21 @@
   # env.GREET = "devenv";
 
   # https://devenv.sh/packages/
-  packages = [ pkgs.git ];
+  packages = [
+    pkgs.git
+    pkgs.nixfmt-rfc-style
+  ];
 
   # https://devenv.sh/languages/
   # languages.rust.enable = true;
-  languages.deno.enable = true;
+  # languages.deno.enable = true;
+  languages.nix.enable = true;
 
   languages.javascript = {
     enable = true;
     npm.enable = true;
-    package = pkgs.nodejs_24;
+    package = pkgs.nodejs_25;
+    bun.enable = true;
   };
 
   # https://devenv.sh/processes/

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
 inputs:
   nixpkgs:
-    url: github:cachix/devenv-nixpkgs/rolling
-
+    # url: github:cachix/devenv-nixpkgs/rolling
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
 # If you're using non-OSS software, you can set allowUnfree to true.
 # allowUnfree: true
 

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,0 +1,28 @@
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+import json from "@eslint/json";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig([
+    { ignores: ["dist/", "types/", "docs/"] },
+    {
+        files: ["**/*.{js,mjs,cjs,ts,mts,cts}"],
+        plugins: { js },
+        extends: ["js/recommended"],
+        languageOptions: { globals: globals.browser },
+    },
+    tseslint.configs.recommended,
+    {
+        files: ["**/*.json"],
+        plugins: { json },
+        language: "json/json",
+        extends: ["json/recommended"],
+    },
+    {
+        files: ["**/*.jsonc"],
+        plugins: { json },
+        language: "json/jsonc",
+        extends: ["json/recommended"],
+    },
+]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,2819 +1,5127 @@
 {
-	"name": "ifunny.ts",
-	"version": "0.8.0",
-	"lockfileVersion": 2,
-	"requires": true,
-	"packages": {
-		"": {
-			"name": "ifunny.ts",
-			"version": "0.8.0",
-			"license": "CC0-1.0",
-			"dependencies": {
-				"@ifunny/ifunny-api-types": "1.0.4",
-				"axios": "1.12.0",
-				"eventemitter3": "5.0.1",
-				"node-ts-cache": "^4.4.0",
-				"node-ts-cache-storage-memory": "^4.4.0"
-			},
-			"devDependencies": {
-				"@types/node": "22.14.0",
-				"@types/readline-sync": "^1.4.4",
-				"auto-changelog": "2.5.0",
-				"dotenv": "^16.0.3",
-				"gh-pages": "6.3.0",
-				"readline-sync": "^1.4.10",
-				"ts-node": "10.9.2",
-				"typedoc-plugin-missing-exports": "4.0.0",
-				"typescript": "5.8.2"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@gerrit0/mini-shiki": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.2.tgz",
-			"integrity": "sha512-vaZNGhGLKMY14HbF53xxHNgFO9Wz+t5lTlGNpl2N9xFiKQ0I5oIe0vKjU9dh7Nb3Dw6lZ7wqUE0ri+zcdpnK+Q==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@shikijs/engine-oniguruma": "^3.2.1",
-				"@shikijs/langs": "^3.2.1",
-				"@shikijs/themes": "^3.2.1",
-				"@shikijs/types": "^3.2.1",
-				"@shikijs/vscode-textmate": "^10.0.2"
-			}
-		},
-		"node_modules/@ifunny/ifunny-api-types": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@ifunny/ifunny-api-types/-/ifunny-api-types-1.0.4.tgz",
-			"integrity": "sha512-sIgDo+Ml8VAQ0a4Psl4HYP4Bo6Z92DCNNNHxO3IKQPvDZDrUAmnIQeikJifMLIU/Atd2VSWgeBH9fjR/qgg86g=="
-		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
-		"node_modules/@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
-			"integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@shikijs/types": "3.2.1",
-				"@shikijs/vscode-textmate": "^10.0.2"
-			}
-		},
-		"node_modules/@shikijs/langs": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.1.tgz",
-			"integrity": "sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@shikijs/types": "3.2.1"
-			}
-		},
-		"node_modules/@shikijs/themes": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.1.tgz",
-			"integrity": "sha512-k5DKJUT8IldBvAm8WcrDT5+7GA7se6lLksR+2E3SvyqGTyFMzU2F9Gb7rmD+t+Pga1MKrYFxDIeyWjMZWM6uBQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@shikijs/types": "3.2.1"
-			}
-		},
-		"node_modules/@shikijs/types": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
-			"integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4"
-			}
-		},
-		"node_modules/@shikijs/vscode-textmate": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"dev": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-			"dev": true
-		},
-		"node_modules/@types/hast": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
-		"node_modules/@types/node": {
-			"version": "22.14.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
-			"integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~6.21.0"
-			}
-		},
-		"node_modules/@types/readline-sync": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/@types/readline-sync/-/readline-sync-1.4.4.tgz",
-			"integrity": "sha512-cFjVIoiamX7U6zkO2VPvXyTxbFDdiRo902IarJuPVxBhpDnXhwSaVE86ip+SCuyWBbEioKCkT4C88RNTxBM1Dw==",
-			"dev": true
-		},
-		"node_modules/@types/unist": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/acorn": {
-			"version": "8.14.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
-		},
-		"node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"license": "Python-2.0",
-			"peer": true
-		},
-		"node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/async": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-		},
-		"node_modules/auto-changelog": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.5.0.tgz",
-			"integrity": "sha512-UTnLjT7I9U2U/xkCUH5buDlp8C7g0SGChfib+iDrJkamcj5kaMqNKHNfbKJw1kthJUq8sUo3i3q2S6FzO/l/wA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"commander": "^7.2.0",
-				"handlebars": "^4.7.7",
-				"import-cwd": "^3.0.0",
-				"node-fetch": "^2.6.1",
-				"parse-github-url": "^1.0.3",
-				"semver": "^7.3.5"
-			},
-			"bin": {
-				"auto-changelog": "src/index.js"
-			},
-			"engines": {
-				"node": ">=8.3"
-			}
-		},
-		"node_modules/axios": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-			"integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
-			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.4",
-				"proxy-from-env": "^1.1.0"
-			}
-		},
-		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/bluebird": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-		},
-		"node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fill-range": "^7.1.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/call-bind-apply-helpers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/commander": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-			"dev": true
-		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
-		},
-		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.3.1"
-			}
-		},
-		"node_modules/dir-glob": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-type": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-			"integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/dunder-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/email-addresses": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
-			"integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
-			"dev": true
-		},
-		"node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/es-define-property": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-			"dependencies": {
-				"es-errors": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-set-tostringtag": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-			"license": "MIT"
-		},
-		"node_modules/fast-glob": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.8"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"reusify": "^1.0.4"
-			}
-		},
-		"node_modules/filename-reserved-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-			"integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/filenamify": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
-			"integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
-			"dev": true,
-			"dependencies": {
-				"filename-reserved-regex": "^2.0.0",
-				"strip-outer": "^1.0.1",
-				"trim-repeated": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-			"dev": true,
-			"dependencies": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-			}
-		},
-		"node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/follow-redirects": {
-			"version": "1.15.6",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/RubenVerborgh"
-				}
-			],
-			"engines": {
-				"node": ">=4.0"
-			},
-			"peerDependenciesMeta": {
-				"debug": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/fs-extra": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-intrinsic": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"math-intrinsics": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"dependencies": {
-				"dunder-proto": "^1.0.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/gh-pages": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
-			"integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"async": "^3.2.4",
-				"commander": "^13.0.0",
-				"email-addresses": "^5.0.0",
-				"filenamify": "^4.3.0",
-				"find-cache-dir": "^3.3.1",
-				"fs-extra": "^11.1.1",
-				"globby": "^11.1.0"
-			},
-			"bin": {
-				"gh-pages": "bin/gh-pages.js",
-				"gh-pages-clean": "bin/gh-pages-clean.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/gh-pages/node_modules/commander": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/gopd": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/handlebars": {
-			"version": "4.7.7",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-			"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5",
-				"neo-async": "^2.6.0",
-				"source-map": "^0.6.1",
-				"wordwrap": "^1.0.0"
-			},
-			"bin": {
-				"handlebars": "bin/handlebars"
-			},
-			"engines": {
-				"node": ">=0.4.7"
-			},
-			"optionalDependencies": {
-				"uglify-js": "^3.1.4"
-			}
-		},
-		"node_modules/has-symbols": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dependencies": {
-				"has-symbols": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/ignore": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/import-cwd": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
-			"integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"import-from": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/import-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-			"integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"resolve-from": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-glob": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-extglob": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/linkify-it": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"uc.micro": "^2.0.0"
-			}
-		},
-		"node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/lunr": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/make-dir/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
-		},
-		"node_modules/markdown-it": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"argparse": "^2.0.1",
-				"entities": "^4.4.0",
-				"linkify-it": "^5.0.0",
-				"mdurl": "^2.0.0",
-				"punycode.js": "^2.3.1",
-				"uc.micro": "^2.1.0"
-			},
-			"bin": {
-				"markdown-it": "bin/markdown-it.mjs"
-			}
-		},
-		"node_modules/math-intrinsics": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/mdurl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/merge2": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/micromatch": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"braces": "^3.0.3",
-				"picomatch": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
-		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"node_modules/neo-async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true
-		},
-		"node_modules/node-fetch": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-			"integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-			"dev": true,
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/node-ts-cache": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/node-ts-cache/-/node-ts-cache-4.4.0.tgz",
-			"integrity": "sha512-ZULcxpzyFfgpOd33PHjwhPz4fkWSfyrwa9sq1j4jyOm+PaBpQDIzB3m5HRiSKdgEBtQhP3g6hX44dnMjnoHiPA==",
-			"dependencies": {
-				"bluebird": "3.7.2",
-				"debug": "^4.3.2",
-				"redis": "^3.1.2"
-			}
-		},
-		"node_modules/node-ts-cache-storage-memory": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/node-ts-cache-storage-memory/-/node-ts-cache-storage-memory-4.4.0.tgz",
-			"integrity": "sha512-eG8tFF4C1/RBmx52cS/dEu63l+Cn+Z6mz16nuTJwNyvtvDHWjsKKM3hg77PA7ddgf2ztaCyen8ZMQnLy191S4g==",
-			"dependencies": {
-				"debug": "^4.3.2",
-				"node-ts-cache": "^4.4.0"
-			}
-		},
-		"node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/parse-github-url": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.3.tgz",
-			"integrity": "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"parse-github-url": "cli.js"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/path-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pkg-dir": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
-			"dependencies": {
-				"find-up": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-		},
-		"node_modules/punycode.js": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/queue-microtask": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/readline-sync": {
-			"version": "1.4.10",
-			"resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
-			"integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/redis": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-			"integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
-			"dependencies": {
-				"denque": "^1.5.0",
-				"redis-commands": "^1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/node-redis"
-			}
-		},
-		"node_modules/redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-		},
-		"node_modules/redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"dependencies": {
-				"redis-errors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/reusify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
-		"node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/strip-outer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-			"dev": true,
-			"dependencies": {
-				"escape-string-regexp": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
-		},
-		"node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true
-		},
-		"node_modules/trim-repeated": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-			"integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
-			"dev": true,
-			"dependencies": {
-				"escape-string-regexp": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/ts-node": {
-			"version": "10.9.2",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/typedoc": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.1.tgz",
-			"integrity": "sha512-Mn2VPNMaxoe/hlBiLriG4U55oyAa3Xo+8HbtEwV7F5WEOPXqtxzGuMZhJYHaqFJpajeQ6ZDUC2c990NAtTbdgw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@gerrit0/mini-shiki": "^3.2.1",
-				"lunr": "^2.3.9",
-				"markdown-it": "^14.1.0",
-				"minimatch": "^9.0.5",
-				"yaml": "^2.7.0 "
-			},
-			"bin": {
-				"typedoc": "bin/typedoc"
-			},
-			"engines": {
-				"node": ">= 18",
-				"pnpm": ">= 10"
-			},
-			"peerDependencies": {
-				"typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
-			}
-		},
-		"node_modules/typedoc-plugin-missing-exports": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-4.0.0.tgz",
-			"integrity": "sha512-Z4ei+853xppDEhcqzyeyRs4+R0kUuKQWnMK1EtSTEd5LFkgkdW5Bdn8vfo/rsCGbYVJxOWU99fxgM1mROw5Fug==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"typedoc": "^0.28.1"
-			}
-		},
-		"node_modules/typescript": {
-			"version": "5.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
-			}
-		},
-		"node_modules/uc.micro": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/uglify-js": {
-			"version": "3.17.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-			"dev": true,
-			"optional": true,
-			"bin": {
-				"uglifyjs": "bin/uglifyjs"
-			},
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true
-		},
-		"node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true
-		},
-		"node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dev": true,
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
-			}
-		},
-		"node_modules/wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-			"dev": true
-		},
-		"node_modules/yaml": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-			"integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		}
-	},
-	"dependencies": {
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			}
-		},
-		"@gerrit0/mini-shiki": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.2.tgz",
-			"integrity": "sha512-vaZNGhGLKMY14HbF53xxHNgFO9Wz+t5lTlGNpl2N9xFiKQ0I5oIe0vKjU9dh7Nb3Dw6lZ7wqUE0ri+zcdpnK+Q==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@shikijs/engine-oniguruma": "^3.2.1",
-				"@shikijs/langs": "^3.2.1",
-				"@shikijs/themes": "^3.2.1",
-				"@shikijs/types": "^3.2.1",
-				"@shikijs/vscode-textmate": "^10.0.2"
-			}
-		},
-		"@ifunny/ifunny-api-types": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@ifunny/ifunny-api-types/-/ifunny-api-types-1.0.4.tgz",
-			"integrity": "sha512-sIgDo+Ml8VAQ0a4Psl4HYP4Bo6Z92DCNNNHxO3IKQPvDZDrUAmnIQeikJifMLIU/Atd2VSWgeBH9fjR/qgg86g=="
-		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-			"dev": true
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
-		"@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
-			"requires": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
-			}
-		},
-		"@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true
-		},
-		"@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
-			"requires": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
-			}
-		},
-		"@shikijs/engine-oniguruma": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
-			"integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@shikijs/types": "3.2.1",
-				"@shikijs/vscode-textmate": "^10.0.2"
-			}
-		},
-		"@shikijs/langs": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.1.tgz",
-			"integrity": "sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@shikijs/types": "3.2.1"
-			}
-		},
-		"@shikijs/themes": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.1.tgz",
-			"integrity": "sha512-k5DKJUT8IldBvAm8WcrDT5+7GA7se6lLksR+2E3SvyqGTyFMzU2F9Gb7rmD+t+Pga1MKrYFxDIeyWjMZWM6uBQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@shikijs/types": "3.2.1"
-			}
-		},
-		"@shikijs/types": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
-			"integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4"
-			}
-		},
-		"@shikijs/vscode-textmate": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node10": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"dev": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-			"dev": true
-		},
-		"@types/hast": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@types/unist": "*"
-			}
-		},
-		"@types/node": {
-			"version": "22.14.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
-			"integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
-			"dev": true,
-			"requires": {
-				"undici-types": "~6.21.0"
-			}
-		},
-		"@types/readline-sync": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/@types/readline-sync/-/readline-sync-1.4.4.tgz",
-			"integrity": "sha512-cFjVIoiamX7U6zkO2VPvXyTxbFDdiRo902IarJuPVxBhpDnXhwSaVE86ip+SCuyWBbEioKCkT4C88RNTxBM1Dw==",
-			"dev": true
-		},
-		"@types/unist": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-			"dev": true,
-			"peer": true
-		},
-		"acorn": {
-			"version": "8.14.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-			"dev": true
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
-		},
-		"argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"peer": true
-		},
-		"array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true
-		},
-		"async": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-			"dev": true
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-		},
-		"auto-changelog": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.5.0.tgz",
-			"integrity": "sha512-UTnLjT7I9U2U/xkCUH5buDlp8C7g0SGChfib+iDrJkamcj5kaMqNKHNfbKJw1kthJUq8sUo3i3q2S6FzO/l/wA==",
-			"dev": true,
-			"requires": {
-				"commander": "^7.2.0",
-				"handlebars": "^4.7.7",
-				"import-cwd": "^3.0.0",
-				"node-fetch": "^2.6.1",
-				"parse-github-url": "^1.0.3",
-				"semver": "^7.3.5"
-			}
-		},
-		"axios": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-			"integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
-			"requires": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.4",
-				"proxy-from-env": "^1.1.0"
-			}
-		},
-		"balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"peer": true
-		},
-		"bluebird": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-		},
-		"brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
-			"requires": {
-				"fill-range": "^7.1.1"
-			}
-		},
-		"call-bind-apply-helpers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"requires": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2"
-			}
-		},
-		"combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
-		"commander": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-			"dev": true
-		},
-		"commondir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-			"dev": true
-		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
-		},
-		"debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"requires": {
-				"ms": "2.1.2"
-			}
-		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-		},
-		"denque": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-			"integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true
-		},
-		"dir-glob": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
-			"requires": {
-				"path-type": "^4.0.0"
-			}
-		},
-		"dotenv": {
-			"version": "16.0.3",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-			"integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-			"dev": true
-		},
-		"dunder-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"requires": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.2.0"
-			}
-		},
-		"email-addresses": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
-			"integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
-			"dev": true
-		},
-		"entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
-			"peer": true
-		},
-		"es-define-property": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-		},
-		"es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-		},
-		"es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-			"requires": {
-				"es-errors": "^1.3.0"
-			}
-		},
-		"es-set-tostringtag": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"requires": {
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
-			}
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true
-		},
-		"eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
-		},
-		"fast-glob": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"dev": true,
-			"requires": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.8"
-			}
-		},
-		"fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-			"dev": true,
-			"requires": {
-				"reusify": "^1.0.4"
-			}
-		},
-		"filename-reserved-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-			"integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
-			"dev": true
-		},
-		"filenamify": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
-			"integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
-			"dev": true,
-			"requires": {
-				"filename-reserved-regex": "^2.0.0",
-				"strip-outer": "^1.0.1",
-				"trim-repeated": "^1.0.0"
-			}
-		},
-		"fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
-			"requires": {
-				"to-regex-range": "^5.0.1"
-			}
-		},
-		"find-cache-dir": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-			"dev": true,
-			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
-			}
-		},
-		"find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"requires": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			}
-		},
-		"follow-redirects": {
-			"version": "1.15.6",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
-		},
-		"form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			}
-		},
-		"fs-extra": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			}
-		},
-		"function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-		},
-		"get-intrinsic": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"requires": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"math-intrinsics": "^1.1.0"
-			}
-		},
-		"get-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"requires": {
-				"dunder-proto": "^1.0.1",
-				"es-object-atoms": "^1.0.0"
-			}
-		},
-		"gh-pages": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
-			"integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
-			"dev": true,
-			"requires": {
-				"async": "^3.2.4",
-				"commander": "^13.0.0",
-				"email-addresses": "^5.0.0",
-				"filenamify": "^4.3.0",
-				"find-cache-dir": "^3.3.1",
-				"fs-extra": "^11.1.1",
-				"globby": "^11.1.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "13.1.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-					"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-					"dev": true
-				}
-			}
-		},
-		"glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"requires": {
-				"is-glob": "^4.0.1"
-			}
-		},
-		"globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
-			"requires": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			}
-		},
-		"gopd": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-		},
-		"graceful-fs": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true
-		},
-		"handlebars": {
-			"version": "4.7.7",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-			"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.5",
-				"neo-async": "^2.6.0",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4",
-				"wordwrap": "^1.0.0"
-			}
-		},
-		"has-symbols": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-		},
-		"has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"requires": {
-				"has-symbols": "^1.0.3"
-			}
-		},
-		"hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"requires": {
-				"function-bind": "^1.1.2"
-			}
-		},
-		"ignore": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"dev": true
-		},
-		"import-cwd": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
-			"integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
-			"dev": true,
-			"requires": {
-				"import-from": "^3.0.0"
-			}
-		},
-		"import-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-			"integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-			"dev": true,
-			"requires": {
-				"resolve-from": "^5.0.0"
-			}
-		},
-		"is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true
-		},
-		"is-glob": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
-			"requires": {
-				"is-extglob": "^2.1.1"
-			}
-		},
-		"is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
-		},
-		"jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.6",
-				"universalify": "^2.0.0"
-			}
-		},
-		"linkify-it": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"uc.micro": "^2.0.0"
-			}
-		},
-		"locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"requires": {
-				"p-locate": "^4.1.0"
-			}
-		},
-		"lunr": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-			"dev": true,
-			"peer": true
-		},
-		"make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
-			"requires": {
-				"semver": "^6.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-					"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-					"dev": true
-				}
-			}
-		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
-		},
-		"markdown-it": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"argparse": "^2.0.1",
-				"entities": "^4.4.0",
-				"linkify-it": "^5.0.0",
-				"mdurl": "^2.0.0",
-				"punycode.js": "^2.3.1",
-				"uc.micro": "^2.1.0"
-			}
-		},
-		"math-intrinsics": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-		},
-		"mdurl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-			"dev": true,
-			"peer": true
-		},
-		"merge2": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true
-		},
-		"micromatch": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
-			"requires": {
-				"braces": "^3.0.3",
-				"picomatch": "^2.3.1"
-			}
-		},
-		"mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-		},
-		"mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"requires": {
-				"mime-db": "1.52.0"
-			}
-		},
-		"minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"brace-expansion": "^2.0.1"
-			}
-		},
-		"minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true
-		},
-		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"neo-async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true
-		},
-		"node-fetch": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-			"integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-			"dev": true,
-			"requires": {
-				"whatwg-url": "^5.0.0"
-			}
-		},
-		"node-ts-cache": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/node-ts-cache/-/node-ts-cache-4.4.0.tgz",
-			"integrity": "sha512-ZULcxpzyFfgpOd33PHjwhPz4fkWSfyrwa9sq1j4jyOm+PaBpQDIzB3m5HRiSKdgEBtQhP3g6hX44dnMjnoHiPA==",
-			"requires": {
-				"bluebird": "3.7.2",
-				"debug": "^4.3.2",
-				"redis": "^3.1.2"
-			}
-		},
-		"node-ts-cache-storage-memory": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/node-ts-cache-storage-memory/-/node-ts-cache-storage-memory-4.4.0.tgz",
-			"integrity": "sha512-eG8tFF4C1/RBmx52cS/dEu63l+Cn+Z6mz16nuTJwNyvtvDHWjsKKM3hg77PA7ddgf2ztaCyen8ZMQnLy191S4g==",
-			"requires": {
-				"debug": "^4.3.2",
-				"node-ts-cache": "^4.4.0"
-			}
-		},
-		"p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"requires": {
-				"p-try": "^2.0.0"
-			}
-		},
-		"p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"requires": {
-				"p-limit": "^2.2.0"
-			}
-		},
-		"p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
-		},
-		"parse-github-url": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.3.tgz",
-			"integrity": "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==",
-			"dev": true
-		},
-		"path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true
-		},
-		"path-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true
-		},
-		"picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true
-		},
-		"pkg-dir": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
-			"requires": {
-				"find-up": "^4.0.0"
-			}
-		},
-		"proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-		},
-		"punycode.js": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-			"dev": true,
-			"peer": true
-		},
-		"queue-microtask": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true
-		},
-		"readline-sync": {
-			"version": "1.4.10",
-			"resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
-			"integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
-			"dev": true
-		},
-		"redis": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-			"integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
-			"requires": {
-				"denque": "^1.5.0",
-				"redis-commands": "^1.7.0",
-				"redis-errors": "^1.2.0",
-				"redis-parser": "^3.0.0"
-			}
-		},
-		"redis-commands": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-			"integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-		},
-		"redis-errors": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-			"integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
-		},
-		"redis-parser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-			"integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-			"requires": {
-				"redis-errors": "^1.0.0"
-			}
-		},
-		"resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true
-		},
-		"reusify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"dev": true
-		},
-		"run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
-			"requires": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
-		"semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-			"dev": true
-		},
-		"slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true
-		},
-		"source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true
-		},
-		"strip-outer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
-		},
-		"to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"requires": {
-				"is-number": "^7.0.0"
-			}
-		},
-		"tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true
-		},
-		"trim-repeated": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-			"integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
-		},
-		"ts-node": {
-			"version": "10.9.2",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-			"dev": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
-		"typedoc": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.1.tgz",
-			"integrity": "sha512-Mn2VPNMaxoe/hlBiLriG4U55oyAa3Xo+8HbtEwV7F5WEOPXqtxzGuMZhJYHaqFJpajeQ6ZDUC2c990NAtTbdgw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@gerrit0/mini-shiki": "^3.2.1",
-				"lunr": "^2.3.9",
-				"markdown-it": "^14.1.0",
-				"minimatch": "^9.0.5",
-				"yaml": "^2.7.0 "
-			}
-		},
-		"typedoc-plugin-missing-exports": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-4.0.0.tgz",
-			"integrity": "sha512-Z4ei+853xppDEhcqzyeyRs4+R0kUuKQWnMK1EtSTEd5LFkgkdW5Bdn8vfo/rsCGbYVJxOWU99fxgM1mROw5Fug==",
-			"dev": true,
-			"requires": {}
-		},
-		"typescript": {
-			"version": "5.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-			"dev": true
-		},
-		"uc.micro": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-			"dev": true,
-			"peer": true
-		},
-		"uglify-js": {
-			"version": "3.17.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-			"dev": true,
-			"optional": true
-		},
-		"undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-			"dev": true
-		},
-		"universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true
-		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true
-		},
-		"webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true
-		},
-		"whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dev": true,
-			"requires": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
-			}
-		},
-		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-			"dev": true
-		},
-		"yaml": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-			"integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-			"dev": true,
-			"peer": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true
-		}
-	}
+    "name": "ifunny.ts",
+    "version": "0.8.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "ifunny.ts",
+            "version": "0.8.0",
+            "license": "CC0-1.0",
+            "dependencies": {
+                "@ifunny/ifunny-api-types": "1.0.4",
+                "axios": "1.13.2",
+                "eventemitter3": "5.0.1",
+                "node-ts-cache": "^4.4.0",
+                "node-ts-cache-storage-memory": "^4.4.0"
+            },
+            "devDependencies": {
+                "@eslint/js": "^9.39.2",
+                "@eslint/json": "^0.14.0",
+                "@types/node": "25.0.2",
+                "@types/readline-sync": "^1.4.8",
+                "@typescript-eslint/eslint-plugin": "^8.49.0",
+                "@typescript-eslint/parser": "^8.49.0",
+                "auto-changelog": "2.5.0",
+                "bun-types": "^1.3.4",
+                "dotenv": "^17.2.3",
+                "eslint": "^9.39.2",
+                "gh-pages": "6.3.0",
+                "globals": "^16.5.0",
+                "jiti": "^2.6.1",
+                "prettier": "^3.7.4",
+                "readline-sync": "^1.4.10",
+                "ts-node": "10.9.2",
+                "typedoc": "^0.28.15",
+                "typescript": "^5.9.3",
+                "typescript-eslint": "^8.49.0"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+            "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@eslint/config-array": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+            "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.7",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+            "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.12.4",
+                "debug": "^4.3.2",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.1.1",
+                "minimatch": "^3.1.2",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "9.39.2",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+            "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            }
+        },
+        "node_modules/@eslint/json": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.14.0.tgz",
+            "integrity": "sha512-rvR/EZtvUG3p9uqrSmcDJPYSH7atmWr0RnFWN6m917MAPx82+zQgPUmDu0whPFG6XTyM0vB/hR6c1Q63OaYtCQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0",
+                "@eslint/plugin-kit": "^0.4.1",
+                "@humanwhocodes/momoa": "^3.3.10",
+                "natural-compare": "^1.4.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0",
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@gerrit0/mini-shiki": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.20.0.tgz",
+            "integrity": "sha512-Wa57i+bMpK6PGJZ1f2myxo3iO+K/kZikcyvH8NIqNNZhQUbDav7V9LQmWOXhf946mz5c1NZ19WMsGYiDKTryzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/engine-oniguruma": "^3.20.0",
+                "@shikijs/langs": "^3.20.0",
+                "@shikijs/themes": "^3.20.0",
+                "@shikijs/types": "^3.20.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
+            }
+        },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.7",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/core": "^0.19.1",
+                "@humanwhocodes/retry": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.22"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@humanwhocodes/momoa": {
+            "version": "3.3.10",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.10.tgz",
+            "integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@ifunny/ifunny-api-types": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@ifunny/ifunny-api-types/-/ifunny-api-types-1.0.4.tgz",
+            "integrity": "sha512-sIgDo+Ml8VAQ0a4Psl4HYP4Bo6Z92DCNNNHxO3IKQPvDZDrUAmnIQeikJifMLIU/Atd2VSWgeBH9fjR/qgg86g=="
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@shikijs/engine-oniguruma": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.20.0.tgz",
+            "integrity": "sha512-Yx3gy7xLzM0ZOjqoxciHjA7dAt5tyzJE3L4uQoM83agahy+PlW244XJSrmJRSBvGYELDhYXPacD4R/cauV5bzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.20.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
+            }
+        },
+        "node_modules/@shikijs/langs": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.20.0.tgz",
+            "integrity": "sha512-le+bssCxcSHrygCWuOrYJHvjus6zhQ2K7q/0mgjiffRbkhM4o1EWu2m+29l0yEsHDbWaWPNnDUTRVVBvBBeKaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.20.0"
+            }
+        },
+        "node_modules/@shikijs/themes": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.20.0.tgz",
+            "integrity": "sha512-U1NSU7Sl26Q7ErRvJUouArxfM2euWqq1xaSrbqMu2iqa+tSp0D1Yah8216sDYbdDHw4C8b75UpE65eWorm2erQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.20.0"
+            }
+        },
+        "node_modules/@shikijs/types": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.20.0.tgz",
+            "integrity": "sha512-lhYAATn10nkZcBQ0BlzSbJA3wcmL5MXUUF8d2Zzon6saZDlToKaiRX60n2+ZaHJCmXEcZRWNzn+k9vplr8Jhsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            }
+        },
+        "node_modules/@shikijs/vscode-textmate": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+            "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+            "dev": true
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "25.0.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
+            "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "undici-types": "~7.16.0"
+            }
+        },
+        "node_modules/@types/readline-sync": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/@types/readline-sync/-/readline-sync-1.4.8.tgz",
+            "integrity": "sha512-BL7xOf0yKLA6baAX6MMOnYkoflUyj/c7y3pqMRfU0va7XlwHAOTOIo4x55P/qLfMsuaYdJJKubToLqRVmRtRZA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz",
+            "integrity": "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "8.49.0",
+                "@typescript-eslint/type-utils": "8.49.0",
+                "@typescript-eslint/utils": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0",
+                "ignore": "^7.0.0",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^8.49.0",
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
+            "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.49.0",
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
+            "integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.49.0",
+                "@typescript-eslint/types": "^8.49.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.49.0.tgz",
+            "integrity": "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
+            "integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.49.0.tgz",
+            "integrity": "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0",
+                "@typescript-eslint/utils": "8.49.0",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.49.0.tgz",
+            "integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
+            "integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.49.0",
+                "@typescript-eslint/tsconfig-utils": "8.49.0",
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0",
+                "debug": "^4.3.4",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.49.0.tgz",
+            "integrity": "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.49.0",
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
+            "integrity": "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.49.0",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/acorn": {
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-jsx": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/async": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+            "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+            "dev": true
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "node_modules/auto-changelog": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.5.0.tgz",
+            "integrity": "sha512-UTnLjT7I9U2U/xkCUH5buDlp8C7g0SGChfib+iDrJkamcj5kaMqNKHNfbKJw1kthJUq8sUo3i3q2S6FzO/l/wA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^7.2.0",
+                "handlebars": "^4.7.7",
+                "import-cwd": "^3.0.0",
+                "node-fetch": "^2.6.1",
+                "parse-github-url": "^1.0.3",
+                "semver": "^7.3.5"
+            },
+            "bin": {
+                "auto-changelog": "src/index.js"
+            },
+            "engines": {
+                "node": ">=8.3"
+            }
+        },
+        "node_modules/axios": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+            "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.4",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+        },
+        "node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/bun-types": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.4.tgz",
+            "integrity": "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+            "dev": true
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/deep-is": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/denque": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+            "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "17.2.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+            "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/email-addresses": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+            "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+            "dev": true
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/eslint": {
+            "version": "9.39.2",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+            "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.8.0",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.21.1",
+                "@eslint/config-helpers": "^0.4.2",
+                "@eslint/core": "^0.17.0",
+                "@eslint/eslintrc": "^3.3.1",
+                "@eslint/js": "9.39.2",
+                "@eslint/plugin-kit": "^0.4.1",
+                "@humanfs/node": "^0.16.6",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@humanwhocodes/retry": "^0.4.2",
+                "@types/estree": "^1.0.6",
+                "ajv": "^6.12.4",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "debug": "^4.3.2",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "esquery": "^1.5.0",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^8.0.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.2",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-scope": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint/node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/eslint/node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/eslint/node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/espree/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/esquery": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "estraverse": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "license": "MIT"
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fastq": {
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/file-entry-cache": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flat-cache": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/filename-reserved-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+            "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/filenamify": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+            "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+            "dev": true,
+            "dependencies": {
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.1",
+                "trim-repeated": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-cache-dir": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+            "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+            "dev": true,
+            "dependencies": {
+                "commondir": "^1.0.1",
+                "make-dir": "^3.0.2",
+                "pkg-dir": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/flat-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.4"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/flatted": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/fs-extra": {
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gh-pages": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
+            "integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "async": "^3.2.4",
+                "commander": "^13.0.0",
+                "email-addresses": "^5.0.0",
+                "filenamify": "^4.3.0",
+                "find-cache-dir": "^3.3.1",
+                "fs-extra": "^11.1.1",
+                "globby": "^11.1.0"
+            },
+            "bin": {
+                "gh-pages": "bin/gh-pages.js",
+                "gh-pages-clean": "bin/gh-pages-clean.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/gh-pages/node_modules/commander": {
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/globals": {
+            "version": "16.5.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+            "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/globby": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/handlebars": {
+            "version": "4.7.7",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.0",
+                "source-map": "^0.6.1",
+                "wordwrap": "^1.0.0"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "^3.1.4"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/import-cwd": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+            "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "import-from": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-fresh/node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/import-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+            "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.19"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/jiti": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/levn": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/linkify-it": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "uc.micro": "^2.0.0"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/make-dir/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true
+        },
+        "node_modules/markdown-it": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.0",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
+        },
+        "node_modules/node-fetch": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/node-ts-cache": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/node-ts-cache/-/node-ts-cache-4.4.0.tgz",
+            "integrity": "sha512-ZULcxpzyFfgpOd33PHjwhPz4fkWSfyrwa9sq1j4jyOm+PaBpQDIzB3m5HRiSKdgEBtQhP3g6hX44dnMjnoHiPA==",
+            "dependencies": {
+                "bluebird": "3.7.2",
+                "debug": "^4.3.2",
+                "redis": "^3.1.2"
+            }
+        },
+        "node_modules/node-ts-cache-storage-memory": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/node-ts-cache-storage-memory/-/node-ts-cache-storage-memory-4.4.0.tgz",
+            "integrity": "sha512-eG8tFF4C1/RBmx52cS/dEu63l+Cn+Z6mz16nuTJwNyvtvDHWjsKKM3hg77PA7ddgf2ztaCyen8ZMQnLy191S4g==",
+            "dependencies": {
+                "debug": "^4.3.2",
+                "node-ts-cache": "^4.4.0"
+            }
+        },
+        "node_modules/optionator": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/parse-github-url": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.3.tgz",
+            "integrity": "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "parse-github-url": "cli.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+            "dev": true,
+            "dependencies": {
+                "find-up": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+            "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/readline-sync": {
+            "version": "1.4.10",
+            "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+            "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/redis": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+            "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+            "dependencies": {
+                "denque": "^1.5.0",
+                "redis-commands": "^1.7.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-redis"
+            }
+        },
+        "node_modules/redis-commands": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+            "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+        },
+        "node_modules/redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "dependencies": {
+                "redis-errors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/reusify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strip-outer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+            "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true
+        },
+        "node_modules/trim-repeated": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+            "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ts-api-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4"
+            }
+        },
+        "node_modules/ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/type-check": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/typedoc": {
+            "version": "0.28.15",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.15.tgz",
+            "integrity": "sha512-mw2/2vTL7MlT+BVo43lOsufkkd2CJO4zeOSuWQQsiXoV2VuEn7f6IZp2jsUDPmBMABpgR0R5jlcJ2OGEFYmkyg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@gerrit0/mini-shiki": "^3.17.0",
+                "lunr": "^2.3.9",
+                "markdown-it": "^14.1.0",
+                "minimatch": "^9.0.5",
+                "yaml": "^2.8.1"
+            },
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 18",
+                "pnpm": ">= 10"
+            },
+            "peerDependencies": {
+                "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-eslint": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.49.0.tgz",
+            "integrity": "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.49.0",
+                "@typescript-eslint/parser": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0",
+                "@typescript-eslint/utils": "8.49.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/uc.micro": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/uglify-js": {
+            "version": "3.17.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "dev": true,
+            "optional": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true
+        },
+        "node_modules/yaml": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        }
+    },
+    "dependencies": {
+        "@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            }
+        },
+        "@eslint-community/eslint-utils": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+            "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^3.4.3"
+            }
+        },
+        "@eslint-community/regexpp": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+            "dev": true
+        },
+        "@eslint/config-array": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+            "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+            "dev": true,
+            "requires": {
+                "@eslint/object-schema": "^2.1.7",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.2"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "1.1.12",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+                    "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
+            }
+        },
+        "@eslint/config-helpers": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+            "dev": true,
+            "requires": {
+                "@eslint/core": "^0.17.0"
+            }
+        },
+        "@eslint/core": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+            "dev": true,
+            "requires": {
+                "@types/json-schema": "^7.0.15"
+            }
+        },
+        "@eslint/eslintrc": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+            "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.4",
+                "debug": "^4.3.2",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.1.1",
+                "minimatch": "^3.1.2",
+                "strip-json-comments": "^3.1.1"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "1.1.12",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+                    "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "globals": {
+                    "version": "14.0.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+                    "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
+            }
+        },
+        "@eslint/js": {
+            "version": "9.39.2",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+            "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+            "dev": true
+        },
+        "@eslint/json": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.14.0.tgz",
+            "integrity": "sha512-rvR/EZtvUG3p9uqrSmcDJPYSH7atmWr0RnFWN6m917MAPx82+zQgPUmDu0whPFG6XTyM0vB/hR6c1Q63OaYtCQ==",
+            "dev": true,
+            "requires": {
+                "@eslint/core": "^0.17.0",
+                "@eslint/plugin-kit": "^0.4.1",
+                "@humanwhocodes/momoa": "^3.3.10",
+                "natural-compare": "^1.4.0"
+            }
+        },
+        "@eslint/object-schema": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+            "dev": true
+        },
+        "@eslint/plugin-kit": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+            "dev": true,
+            "requires": {
+                "@eslint/core": "^0.17.0",
+                "levn": "^0.4.1"
+            }
+        },
+        "@gerrit0/mini-shiki": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.20.0.tgz",
+            "integrity": "sha512-Wa57i+bMpK6PGJZ1f2myxo3iO+K/kZikcyvH8NIqNNZhQUbDav7V9LQmWOXhf946mz5c1NZ19WMsGYiDKTryzQ==",
+            "dev": true,
+            "requires": {
+                "@shikijs/engine-oniguruma": "^3.20.0",
+                "@shikijs/langs": "^3.20.0",
+                "@shikijs/themes": "^3.20.0",
+                "@shikijs/types": "^3.20.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
+            }
+        },
+        "@humanfs/core": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "dev": true
+        },
+        "@humanfs/node": {
+            "version": "0.16.7",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+            "dev": true,
+            "requires": {
+                "@humanfs/core": "^0.19.1",
+                "@humanwhocodes/retry": "^0.4.0"
+            }
+        },
+        "@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true
+        },
+        "@humanwhocodes/momoa": {
+            "version": "3.3.10",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.10.tgz",
+            "integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
+            "dev": true
+        },
+        "@humanwhocodes/retry": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+            "dev": true
+        },
+        "@ifunny/ifunny-api-types": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@ifunny/ifunny-api-types/-/ifunny-api-types-1.0.4.tgz",
+            "integrity": "sha512-sIgDo+Ml8VAQ0a4Psl4HYP4Bo6Z92DCNNNHxO3IKQPvDZDrUAmnIQeikJifMLIU/Atd2VSWgeBH9fjR/qgg86g=="
+        },
+        "@jridgewell/resolve-uri": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "dev": true
+        },
+        "@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
+        },
+        "@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            }
+        },
+        "@shikijs/engine-oniguruma": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.20.0.tgz",
+            "integrity": "sha512-Yx3gy7xLzM0ZOjqoxciHjA7dAt5tyzJE3L4uQoM83agahy+PlW244XJSrmJRSBvGYELDhYXPacD4R/cauV5bzQ==",
+            "dev": true,
+            "requires": {
+                "@shikijs/types": "3.20.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
+            }
+        },
+        "@shikijs/langs": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.20.0.tgz",
+            "integrity": "sha512-le+bssCxcSHrygCWuOrYJHvjus6zhQ2K7q/0mgjiffRbkhM4o1EWu2m+29l0yEsHDbWaWPNnDUTRVVBvBBeKaA==",
+            "dev": true,
+            "requires": {
+                "@shikijs/types": "3.20.0"
+            }
+        },
+        "@shikijs/themes": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.20.0.tgz",
+            "integrity": "sha512-U1NSU7Sl26Q7ErRvJUouArxfM2euWqq1xaSrbqMu2iqa+tSp0D1Yah8216sDYbdDHw4C8b75UpE65eWorm2erQ==",
+            "dev": true,
+            "requires": {
+                "@shikijs/types": "3.20.0"
+            }
+        },
+        "@shikijs/types": {
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.20.0.tgz",
+            "integrity": "sha512-lhYAATn10nkZcBQ0BlzSbJA3wcmL5MXUUF8d2Zzon6saZDlToKaiRX60n2+ZaHJCmXEcZRWNzn+k9vplr8Jhsw==",
+            "dev": true,
+            "requires": {
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            }
+        },
+        "@shikijs/vscode-textmate": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+            "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+            "dev": true
+        },
+        "@tsconfig/node10": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+            "dev": true
+        },
+        "@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+            "dev": true
+        },
+        "@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true
+        },
+        "@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "dev": true,
+            "requires": {
+                "@types/unist": "*"
+            }
+        },
+        "@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "25.0.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
+            "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "undici-types": "~7.16.0"
+            }
+        },
+        "@types/readline-sync": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/@types/readline-sync/-/readline-sync-1.4.8.tgz",
+            "integrity": "sha512-BL7xOf0yKLA6baAX6MMOnYkoflUyj/c7y3pqMRfU0va7XlwHAOTOIo4x55P/qLfMsuaYdJJKubToLqRVmRtRZA==",
+            "dev": true
+        },
+        "@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "dev": true
+        },
+        "@typescript-eslint/eslint-plugin": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz",
+            "integrity": "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==",
+            "dev": true,
+            "requires": {
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "8.49.0",
+                "@typescript-eslint/type-utils": "8.49.0",
+                "@typescript-eslint/utils": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0",
+                "ignore": "^7.0.0",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "dependencies": {
+                "ignore": {
+                    "version": "7.0.5",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+                    "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+                    "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/parser": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
+            "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@typescript-eslint/scope-manager": "8.49.0",
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0",
+                "debug": "^4.3.4"
+            }
+        },
+        "@typescript-eslint/project-service": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
+            "integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/tsconfig-utils": "^8.49.0",
+                "@typescript-eslint/types": "^8.49.0",
+                "debug": "^4.3.4"
+            }
+        },
+        "@typescript-eslint/scope-manager": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.49.0.tgz",
+            "integrity": "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0"
+            }
+        },
+        "@typescript-eslint/tsconfig-utils": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
+            "integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
+            "dev": true,
+            "requires": {}
+        },
+        "@typescript-eslint/type-utils": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.49.0.tgz",
+            "integrity": "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0",
+                "@typescript-eslint/utils": "8.49.0",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^2.1.0"
+            }
+        },
+        "@typescript-eslint/types": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.49.0.tgz",
+            "integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
+            "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
+            "integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/project-service": "8.49.0",
+                "@typescript-eslint/tsconfig-utils": "8.49.0",
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0",
+                "debug": "^4.3.4",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.1.0"
+            }
+        },
+        "@typescript-eslint/utils": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.49.0.tgz",
+            "integrity": "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==",
+            "dev": true,
+            "requires": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.49.0",
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0"
+            }
+        },
+        "@typescript-eslint/visitor-keys": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
+            "integrity": "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "8.49.0",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+                    "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+                    "dev": true
+                }
+            }
+        },
+        "acorn": {
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "dev": true,
+            "peer": true
+        },
+        "acorn-jsx": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
+            "requires": {}
+        },
+        "acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^2.0.1"
+            }
+        },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true
+        },
+        "argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true
+        },
+        "async": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+            "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "auto-changelog": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.5.0.tgz",
+            "integrity": "sha512-UTnLjT7I9U2U/xkCUH5buDlp8C7g0SGChfib+iDrJkamcj5kaMqNKHNfbKJw1kthJUq8sUo3i3q2S6FzO/l/wA==",
+            "dev": true,
+            "requires": {
+                "commander": "^7.2.0",
+                "handlebars": "^4.7.7",
+                "import-cwd": "^3.0.0",
+                "node-fetch": "^2.6.1",
+                "parse-github-url": "^1.0.3",
+                "semver": "^7.3.5"
+            }
+        },
+        "axios": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+            "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+            "requires": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.4",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
+        },
+        "bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+        },
+        "brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "requires": {
+                "fill-range": "^7.1.1"
+            }
+        },
+        "bun-types": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.4.tgz",
+            "integrity": "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            }
+        },
+        "callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true
+        },
+        "chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            }
+        },
+        "color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "~1.1.4"
+            }
+        },
+        "color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
+        },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
+        },
+        "cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            }
+        },
+        "debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "deep-is": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+        },
+        "denque": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+            "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true
+        },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            }
+        },
+        "dotenv": {
+            "version": "17.2.3",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+            "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+            "dev": true
+        },
+        "dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            }
+        },
+        "email-addresses": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+            "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+            "dev": true
+        },
+        "entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true
+        },
+        "es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+        },
+        "es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "requires": {
+                "es-errors": "^1.3.0"
+            }
+        },
+        "es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true
+        },
+        "eslint": {
+            "version": "9.39.2",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+            "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@eslint-community/eslint-utils": "^4.8.0",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.21.1",
+                "@eslint/config-helpers": "^0.4.2",
+                "@eslint/core": "^0.17.0",
+                "@eslint/eslintrc": "^3.3.1",
+                "@eslint/js": "9.39.2",
+                "@eslint/plugin-kit": "^0.4.1",
+                "@humanfs/node": "^0.16.6",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@humanwhocodes/retry": "^0.4.2",
+                "@types/estree": "^1.0.6",
+                "ajv": "^6.12.4",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "debug": "^4.3.2",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "esquery": "^1.5.0",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^8.0.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.2",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "1.1.12",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+                    "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
+                },
+                "eslint-visitor-keys": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+                    "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+                    "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^6.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "glob-parent": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.3"
+                    }
+                },
+                "locate-path": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+                    "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^5.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "p-limit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                    "dev": true,
+                    "requires": {
+                        "yocto-queue": "^0.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+                    "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^3.0.2"
+                    }
+                }
+            }
+        },
+        "eslint-scope": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true
+        },
+        "espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "dev": true,
+            "requires": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+                    "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+                    "dev": true
+                }
+            }
+        },
+        "esquery": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.1.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.2.0"
+            }
+        },
+        "estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true
+        },
+        "eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
+        },
+        "fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            }
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+            "dev": true
+        },
+        "fastq": {
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "file-entry-cache": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+            "dev": true,
+            "requires": {
+                "flat-cache": "^4.0.0"
+            }
+        },
+        "filename-reserved-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+            "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+            "dev": true
+        },
+        "filenamify": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+            "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+            "dev": true,
+            "requires": {
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.1",
+                "trim-repeated": "^1.0.0"
+            }
+        },
+        "fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "requires": {
+                "to-regex-range": "^5.0.1"
+            }
+        },
+        "find-cache-dir": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+            "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^3.0.2",
+                "pkg-dir": "^4.1.0"
+            }
+        },
+        "find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            }
+        },
+        "flat-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+            "dev": true,
+            "requires": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.4"
+            }
+        },
+        "flatted": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "dev": true
+        },
+        "follow-redirects": {
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+        },
+        "form-data": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "fs-extra": {
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            }
+        },
+        "function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        },
+        "get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            }
+        },
+        "get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "requires": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            }
+        },
+        "gh-pages": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
+            "integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
+            "dev": true,
+            "requires": {
+                "async": "^3.2.4",
+                "commander": "^13.0.0",
+                "email-addresses": "^5.0.0",
+                "filenamify": "^4.3.0",
+                "find-cache-dir": "^3.3.1",
+                "fs-extra": "^11.1.1",
+                "globby": "^11.1.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "13.1.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+                    "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+                    "dev": true
+                }
+            }
+        },
+        "glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
+        "globals": {
+            "version": "16.5.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+            "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+            "dev": true
+        },
+        "globby": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
+            "requires": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            }
+        },
+        "gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+        },
+        "graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.7.7",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.0",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4",
+                "wordwrap": "^1.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+        },
+        "has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "requires": {
+                "has-symbols": "^1.0.3"
+            }
+        },
+        "hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "requires": {
+                "function-bind": "^1.1.2"
+            }
+        },
+        "ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true
+        },
+        "import-cwd": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+            "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+            "dev": true,
+            "requires": {
+                "import-from": "^3.0.0"
+            }
+        },
+        "import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
+        },
+        "import-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+            "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+            "dev": true,
+            "requires": {
+                "resolve-from": "^5.0.0"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
+        },
+        "is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
+        },
+        "jiti": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "dev": true,
+            "peer": true
+        },
+        "js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dev": true,
+            "requires": {
+                "argparse": "^2.0.1"
+            }
+        },
+        "json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            }
+        },
+        "keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "requires": {
+                "json-buffer": "3.0.1"
+            }
+        },
+        "levn": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            }
+        },
+        "linkify-it": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "dev": true,
+            "requires": {
+                "uc.micro": "^2.0.0"
+            }
+        },
+        "locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "requires": {
+                "p-locate": "^4.1.0"
+            }
+        },
+        "lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true
+        },
+        "lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
+        },
+        "make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "requires": {
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+                    "dev": true
+                }
+            }
+        },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true
+        },
+        "markdown-it": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "dev": true,
+            "requires": {
+                "argparse": "^2.0.1",
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.0",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
+            }
+        },
+        "math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+        },
+        "mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "dev": true
+        },
+        "merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true
+        },
+        "micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "requires": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            }
+        },
+        "mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+        },
+        "mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "requires": {
+                "mime-db": "1.52.0"
+            }
+        },
+        "minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^2.0.1"
+            }
+        },
+        "minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
+        },
+        "node-fetch": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+            "dev": true,
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
+        },
+        "node-ts-cache": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/node-ts-cache/-/node-ts-cache-4.4.0.tgz",
+            "integrity": "sha512-ZULcxpzyFfgpOd33PHjwhPz4fkWSfyrwa9sq1j4jyOm+PaBpQDIzB3m5HRiSKdgEBtQhP3g6hX44dnMjnoHiPA==",
+            "requires": {
+                "bluebird": "3.7.2",
+                "debug": "^4.3.2",
+                "redis": "^3.1.2"
+            }
+        },
+        "node-ts-cache-storage-memory": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/node-ts-cache-storage-memory/-/node-ts-cache-storage-memory-4.4.0.tgz",
+            "integrity": "sha512-eG8tFF4C1/RBmx52cS/dEu63l+Cn+Z6mz16nuTJwNyvtvDHWjsKKM3hg77PA7ddgf2ztaCyen8ZMQnLy191S4g==",
+            "requires": {
+                "debug": "^4.3.2",
+                "node-ts-cache": "^4.4.0"
+            }
+        },
+        "optionator": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+            "dev": true,
+            "requires": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
+            }
+        },
+        "p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.2.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true
+        },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
+        "parse-github-url": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.3.tgz",
+            "integrity": "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true
+        },
+        "path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true
+        },
+        "path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true
+        },
+        "picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true
+        },
+        "pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+            "dev": true,
+            "requires": {
+                "find-up": "^4.0.0"
+            }
+        },
+        "prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true
+        },
+        "prettier": {
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+            "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+            "dev": true
+        },
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        },
+        "punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true
+        },
+        "punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+            "dev": true
+        },
+        "queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true
+        },
+        "readline-sync": {
+            "version": "1.4.10",
+            "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+            "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+            "dev": true
+        },
+        "redis": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+            "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+            "requires": {
+                "denque": "^1.5.0",
+                "redis-commands": "^1.7.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0"
+            }
+        },
+        "redis-commands": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+            "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+        },
+        "redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+        },
+        "redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "requires": {
+                "redis-errors": "^1.0.0"
+            }
+        },
+        "resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true
+        },
+        "reusify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "dev": true
+        },
+        "run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "requires": {
+                "queue-microtask": "^1.2.2"
+            }
+        },
+        "semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^3.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true
+        },
+        "slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true
+        },
+        "strip-outer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+            "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.2"
+            }
+        },
+        "supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^4.0.0"
+            }
+        },
+        "tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "requires": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "dependencies": {
+                "fdir": {
+                    "version": "6.5.0",
+                    "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+                    "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+                    "dev": true,
+                    "requires": {}
+                },
+                "picomatch": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+                    "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+                    "dev": true,
+                    "peer": true
+                }
+            }
+        },
+        "to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "requires": {
+                "is-number": "^7.0.0"
+            }
+        },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true
+        },
+        "trim-repeated": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+            "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.2"
+            }
+        },
+        "ts-api-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+            "dev": true,
+            "requires": {}
+        },
+        "ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+            "dev": true,
+            "requires": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            }
+        },
+        "type-check": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "^1.2.1"
+            }
+        },
+        "typedoc": {
+            "version": "0.28.15",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.15.tgz",
+            "integrity": "sha512-mw2/2vTL7MlT+BVo43lOsufkkd2CJO4zeOSuWQQsiXoV2VuEn7f6IZp2jsUDPmBMABpgR0R5jlcJ2OGEFYmkyg==",
+            "dev": true,
+            "requires": {
+                "@gerrit0/mini-shiki": "^3.17.0",
+                "lunr": "^2.3.9",
+                "markdown-it": "^14.1.0",
+                "minimatch": "^9.0.5",
+                "yaml": "^2.8.1"
+            }
+        },
+        "typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "peer": true
+        },
+        "typescript-eslint": {
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.49.0.tgz",
+            "integrity": "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/eslint-plugin": "8.49.0",
+                "@typescript-eslint/parser": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0",
+                "@typescript-eslint/utils": "8.49.0"
+            }
+        },
+        "uc.micro": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "3.17.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "dev": true,
+            "optional": true
+        },
+        "undici-types": {
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "dev": true
+        },
+        "universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true
+        },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true
+        },
+        "yaml": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "dev": true
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true
+        },
+        "yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "push": "npm run rebuild && git push && npm publish && npx gh-pages -d doc -t true",
         "update-deps": "npx npm-check-updates -u && npm install",
         "login": "npx ts-node login.ts",
-        "publish:pages": "gh-pages -d ./docs/"
+        "publish:pages": "gh-pages -d ./docs/",
+        "prepare": "npm run build:dist && npm run build:types"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,68 +1,93 @@
 {
-	"name": "ifunny.ts",
-	"version": "0.8.0",
-	"description": "An iFunny API wrapper written in TypeScript",
-	"main": "dist",
-	"types": "types",
-	"scripts": {
-		"test": "tsc --noEmit",
-		"changelog": "auto-changelog -p  && git add CHANGELOG.md",
-		"changelog:debug": "auto-changelog -p --template json --output changelog-data.json",
-		"clean": "rm -r -f ./dist && rm -r -f ./types",
-		"build": "tsc",
-		"docs": "rm -r -f ./doc && npx typedoc --out doc src",
-		"rebuild": "npm run clean && npm run build",
-		"version": "npm run rebuild && npm run changelog",
-		"push": "npm run rebuild && git push && npm publish && npx gh-pages -d doc -t true",
-		"update-deps": "npx npm-check-updates -u && npm install",
-		"login": "npx ts-node login.ts"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/MakeShiftArtist/ifunny.ts"
-	},
-	"keywords": [
-		"ifunny",
-		"typescript",
-		"api",
-		"library",
-		"ifunny.co"
-	],
-	"author": "",
-	"license": "CC0-1.0",
-	"bugs": {
-		"url": "https://github.com/MakeShiftArtist/iFunny.ts/issues"
-	},
-	"homepage": "https://github.com/MakeShiftArtist/iFunny.ts#readme",
-	"devDependencies": {
-		"@types/node": "22.14.0",
-		"@types/readline-sync": "^1.4.4",
-		"auto-changelog": "2.5.0",
-		"dotenv": "^16.0.3",
-		"gh-pages": "6.3.0",
-		"readline-sync": "^1.4.10",
-		"ts-node": "10.9.2",
-		"typedoc-plugin-missing-exports": "4.0.0",
-		"typescript": "5.8.2"
-	},
-	"dependencies": {
-		"@ifunny/ifunny-api-types": "1.0.4",
-		"axios": "1.12.0",
-		"eventemitter3": "5.0.1",
-		"node-ts-cache": "^4.4.0",
-		"node-ts-cache-storage-memory": "^4.4.0"
-	},
-	"auto-changelog": {
-		"template": "changelog-template.hbs",
-		"hideEmptyReleases": true,
-		"commitLimit": false,
-		"unreleased": true,
-		"replaceText": {
-			"[Ff]eat:": "",
-			"[Ff]ix:": "",
-			"[Bb]reak:": "",
-			"[Dd]oc:": "",
-			"[Cc]hore:": ""
-		}
-	}
+    "name": "ifunny.ts",
+    "version": "0.8.0",
+    "description": "An iFunny API wrapper written in TypeScript",
+    "module": "src/index.ts",
+    "type": "module",
+    "main": "dist/src",
+    "types": "./types/index.d.ts",
+    "exports": {
+        ".": "./dist/index.js"
+    },
+    "scripts": {
+        "test": "tsc --noEmit",
+        "changelog": "auto-changelog -p  && git add CHANGELOG.md",
+        "changelog:debug": "auto-changelog -p --template json --output changelog-data.json",
+        "clean": "npm run clean:dist && npm run clean:types && npm run clean:docs",
+        "clean:dist": "rm -rf ./dist",
+        "clean:types": "rm -rf ./types",
+        "clean:docs": "rm -rf ./docs",
+        "build:dist": "bun build --target=node ./src --outfile ./dist/index.js",
+        "build:types": "tsc --emitDeclarationOnly",
+        "build:docs": "typedoc",
+        "build": "npm run build:dist &&  npm run build:docs && npm run build:types",
+        "build:declaration": "tsc",
+        "lint": "eslint",
+        "rebuild": "npm run clean && npm run build",
+        "version": "npm run rebuild && npm run changelog",
+        "push": "npm run rebuild && git push && npm publish && npx gh-pages -d doc -t true",
+        "update-deps": "npx npm-check-updates -u && npm install",
+        "login": "npx ts-node login.ts",
+        "publish:pages": "gh-pages -d ./docs/"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MakeShiftArtist/ifunny.ts"
+    },
+    "keywords": [
+        "ifunny",
+        "typescript",
+        "api",
+        "library",
+        "ifunny.co"
+    ],
+    "author": "",
+    "license": "CC0-1.0",
+    "bugs": {
+        "url": "https://github.com/MakeShiftArtist/iFunny.ts/issues"
+    },
+    "homepage": "https://github.com/MakeShiftArtist/iFunny.ts#readme",
+    "devDependencies": {
+        "@eslint/js": "^9.39.2",
+        "@eslint/json": "^0.14.0",
+        "@types/node": "25.0.2",
+        "@types/readline-sync": "^1.4.8",
+        "@typescript-eslint/eslint-plugin": "^8.49.0",
+        "@typescript-eslint/parser": "^8.49.0",
+        "auto-changelog": "2.5.0",
+        "bun-types": "^1.3.4",
+        "dotenv": "^17.2.3",
+        "eslint": "^9.39.2",
+        "gh-pages": "6.3.0",
+        "globals": "^16.5.0",
+        "jiti": "^2.6.1",
+        "prettier": "^3.7.4",
+        "readline-sync": "^1.4.10",
+        "ts-node": "10.9.2",
+        "typedoc": "^0.28.15",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.49.0"
+    },
+    "dependencies": {
+        "@ifunny/ifunny-api-types": "1.0.4",
+        "axios": "1.13.2",
+        "eventemitter3": "5.0.1",
+        "node-ts-cache": "^4.4.0",
+        "node-ts-cache-storage-memory": "^4.4.0"
+    },
+    "auto-changelog": {
+        "template": "changelog-template.hbs",
+        "hideEmptyReleases": true,
+        "commitLimit": false,
+        "unreleased": true,
+        "replaceText": {
+            "[Ff]eat:": "",
+            "[Ff]ix:": "",
+            "[Bb]reak:": "",
+            "[Dd]oc:": "",
+            "[Cc]hore:": "",
+            "[Rr]efactor:": "",
+            "[Ss]tyle:": ""
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "build": "npm run build:dist &&  npm run build:docs && npm run build:types",
         "build:declaration": "tsc",
         "lint": "eslint",
+        "format": "prettier ./src/ -w",
         "rebuild": "npm run clean && npm run build",
         "version": "npm run rebuild && npm run changelog",
         "push": "npm run rebuild && git push && npm publish && npx gh-pages -d doc -t true",

--- a/src/client/BaseClient.ts
+++ b/src/client/BaseClient.ts
@@ -1,25 +1,25 @@
 import { Agent } from "https";
 import {
-	APIBase,
-	APIVersion,
-	DefaultHeaders,
-	DefaultClientId,
-	DefaultClientSecret,
-	DefaultBasicTokenLength,
+    APIBase,
+    APIVersion,
+    DefaultHeaders,
+    DefaultClientId,
+    DefaultClientSecret,
+    DefaultBasicTokenLength,
 } from "../utils/Constants";
 import { APIClientUser as ClientPayload } from "@ifunny/ifunny-api-types";
 import { EventEmitter } from "eventemitter3";
 import { ICachingOptions } from "node-ts-cache";
-import axios, { AxiosHeaders, AxiosInstance } from "axios";
+import axios, { AxiosInstance } from "axios";
 
 export interface ClientConfig {
-	basic: string | null;
-	basicLength: 156 | 112;
-	bearer: string | null;
-	headers: AxiosHeaders;
-	clientId: string;
-	clientSecret: string;
-	cacheConfig: ICachingOptions;
+    basic: string | null;
+    basicLength: 156 | 112;
+    bearer: string | null;
+    headers: Record<string, string>;
+    clientId: string;
+    clientSecret: string;
+    cacheConfig: ICachingOptions;
 }
 
 export type ClientOptions = Partial<ClientConfig>;
@@ -29,108 +29,108 @@ export type ClientOptions = Partial<ClientConfig>;
  * @extends EventEmitter
  */
 export class BaseClient extends EventEmitter {
-	/**
-	 * The axios instance used for requests
-	 * @internal
-	 */
-	readonly instance: AxiosInstance;
+    /**
+     * The axios instance used for requests
+     * @internal
+     */
+    readonly instance: AxiosInstance;
 
-	/**
-	 * The payload for the client
-	 */
-	#payload: Partial<ClientPayload>;
+    /**
+     * The payload for the client
+     */
+    #payload: Partial<ClientPayload>;
 
-	/**
-	 * The config for the client
-	 */
-	#config: ClientConfig;
+    /**
+     * The config for the client
+     */
+    #config: ClientConfig;
 
-	/**
-	 * @param config Options to initialize the BaseClient with
-	 * @param payload The payload for the client if applicable
-	 */
-	protected constructor(
-		config: ClientOptions = {},
-		payload: Partial<ClientPayload> = {}
-	) {
-		super();
-		// Set defaults
-		this.#config = Object.assign(BaseClient.DEFAULT_CONFIG, config);
+    /**
+     * @param config Options to initialize the BaseClient with
+     * @param payload The payload for the client if applicable
+     */
+    protected constructor(
+        config: ClientOptions = {},
+        payload: Partial<ClientPayload> = {},
+    ) {
+        super();
+        // Set defaults
+        this.#config = Object.assign(BaseClient.DEFAULT_CONFIG, config);
 
-		const headers = Object.assign(DefaultHeaders, config?.headers);
+        const headers = Object.assign(DefaultHeaders, config?.headers);
 
-		this.instance = axios.create({
-			baseURL: `https://${APIBase}/v${APIVersion}`,
-			headers,
-			httpsAgent: new Agent({ keepAlive: true }),
-		});
+        this.instance = axios.create({
+            baseURL: `https://${APIBase}/v${APIVersion}`,
+            headers,
+            httpsAgent: new Agent({ keepAlive: true }),
+        });
 
-		this.#payload = Object.assign({}, payload);
-	}
+        this.#payload = Object.assign({}, payload);
+    }
 
-	/**
-	 * Default Config for the Client
-	 */
-	public static readonly DEFAULT_CONFIG: ClientConfig = {
-		basic: null,
-		basicLength: DefaultBasicTokenLength,
-		bearer: null,
-		headers: DefaultHeaders,
-		clientId: DefaultClientId,
-		clientSecret: DefaultClientSecret,
-		cacheConfig: {
-			ttl: 1000 * 60 * 30,
-			isLazy: true,
-			isCachedForever: false,
-			calculateKey: JSON.stringify,
-		},
-	};
+    /**
+     * Default Config for the Client
+     */
+    public static readonly DEFAULT_CONFIG: ClientConfig = {
+        basic: null,
+        basicLength: DefaultBasicTokenLength,
+        bearer: null,
+        headers: DefaultHeaders,
+        clientId: DefaultClientId,
+        clientSecret: DefaultClientSecret,
+        cacheConfig: {
+            ttl: 1000 * 60 * 30,
+            isLazy: true,
+            isCachedForever: false,
+            calculateKey: JSON.stringify,
+        },
+    };
 
-	/**
-	 * Current config for the Client
-	 */
-	public get config(): ClientConfig {
-		return this.#config;
-	}
+    /**
+     * Current config for the Client
+     */
+    public get config(): ClientConfig {
+        return this.#config;
+    }
 
-	/**
-	 * Gets the payload
-	 */
-	public get payload(): Partial<ClientPayload> {
-		return this.#payload;
-	}
+    /**
+     * Gets the payload
+     */
+    public get payload(): Partial<ClientPayload> {
+        return this.#payload;
+    }
 
-	/**
-	 * Prevents overwriting the payload
-	 */
-	public set payload(value: Partial<ClientPayload>) {
-		this.#payload = Object.assign(this.payload, value);
-	}
+    /**
+     * Prevents overwriting the payload
+     */
+    public set payload(value: Partial<ClientPayload>) {
+        this.#payload = Object.assign(this.payload, value);
+    }
 
-	/**
-	 * Calls eval with the client set as the "this" context.
-	 * @param script The script to evaluate
-	 * @returns The result of the script
-	 */
-	protected _eval(script: string) {
-		return eval(script);
-	}
+    /**
+     * Calls eval with the client set as the "this" context.
+     * @param script The script to evaluate
+     * @returns The result of the script
+     */
+    protected _eval(script: string) {
+        return eval(script);
+    }
 
-	/**
-	 * Converts the Client's payload into JSON like data
-	 * @returns JSON string representation of the Client
-	 */
-	public toJSON(): string {
-		return JSON.stringify(this.payload, null, 2);
-	}
+    /**
+     * Converts the Client's payload into JSON like data
+     * @returns JSON string representation of the Client
+     */
+    public toJSON(): string {
+        return JSON.stringify(this.payload, null, 2);
+    }
 
-	/**
-	 * When concatenated with a string, this automatically returns the user's nick instead of the User object.
-	 * @example
-	 * console.log(`Hello from ${client}!`); //  Logs: "Hello from iFunnyChef" or "Hello from Guest Client"
-	 */
-	public override toString(): string {
-		return `${this.payload.nick ?? "Guest Client"}`;
-	}
+    /**
+     * When concatenated with a string, this automatically returns the user's nick instead of the User object.
+     * @example
+     * console.log(`Hello from ${client}!`); //  Logs: "Hello from iFunnyChef" or "Hello from Guest Client"
+     */
+    public override toString(): string {
+        return `${this.payload.nick ?? "Guest Client"}`;
+    }
 }
 export default BaseClient;

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -1,9 +1,9 @@
 import {
-	APIClientUser,
-	Endpoints,
-	RESTAPIOauth2LoginSuccess,
-	RESTAPISignUpSuccess,
-	RESTAPISuccessResponse as Success,
+    APIClientUser,
+    Endpoints,
+    RESTAPIOauth2LoginSuccess,
+    RESTAPISignUpSuccess,
+    RESTAPISuccessResponse as Success,
 } from "@ifunny/ifunny-api-types";
 import { BaseClient } from "./BaseClient";
 import { CaptchaError } from "../errors/CaptchaError";
@@ -22,26 +22,26 @@ import User from "../structures/User";
  * Method params for Client#signUp()
  */
 export interface SignUpOptions {
-	/**
-	 * The nick to use when creating the account
-	 */
-	nick: string;
-	/**
-	 * Email / Username for the account
-	 */
-	email: string;
-	/**
-	 * Password for the account
-	 */
-	password: string;
-	/**
-	 * Should the Client sign up for mail offers? Never set this to true you weirdo
-	 */
-	acceptMailing?: boolean;
-	/**
-	 * Should the Client login to the account after creating it?
-	 */
-	login?: boolean;
+    /**
+     * The nick to use when creating the account
+     */
+    nick: string;
+    /**
+     * Email / Username for the account
+     */
+    email: string;
+    /**
+     * Password for the account
+     */
+    password: string;
+    /**
+     * Should the Client sign up for mail offers? Never set this to true you weirdo
+     */
+    acceptMailing?: boolean;
+    /**
+     * Should the Client login to the account after creating it?
+     */
+    login?: boolean;
 }
 
 /**
@@ -50,296 +50,298 @@ export interface SignUpOptions {
  * @template Authorized
  */
 export class Client<Authorized extends boolean = boolean> extends BaseClient {
-	/**
-	 * User manager object
-	 */
-	readonly #users: UserManager;
-	/**
-	 * Feed manager object
-	 */
-	readonly #feeds: FeedManager;
-	/**
-	 * Content manager object
-	 */
-	readonly #content: ContentManager;
-	readonly #app: AppManager;
-	#user: User | null = null;
+    /**
+     * User manager object
+     */
+    readonly #users: UserManager;
+    /**
+     * Feed manager object
+     */
+    readonly #feeds: FeedManager;
+    /**
+     * Content manager object
+     */
+    readonly #content: ContentManager;
+    readonly #app: AppManager;
+    #user: User | null = null;
 
-	/**
-	 * Client utility class
-	 */
-	readonly #util: Util;
+    /**
+     * Client utility class
+     */
+    readonly #util: Util;
 
-	/**
-	 * @param config The config for the Client
-	 * @param payload Payload for the client if applicable
-	 */
-	public constructor(
-		config?: ClientOptions,
-		payload: Partial<APIClientUser> = {}
-	) {
-		super(config, payload);
-		this.#util = new Util(this);
-		this.#users = new UserManager(this, this.config.cacheConfig);
-		this.#content = new ContentManager(this, this.config.cacheConfig);
-		this.#feeds = new FeedManager(this);
-		this.#app = new AppManager(this);
+    /**
+     * @param config The config for the Client
+     * @param payload Payload for the client if applicable
+     */
+    public constructor(
+        config?: ClientOptions,
+        payload: Partial<APIClientUser> = {},
+    ) {
+        super(config, payload);
+        this.#util = new Util(this);
+        this.#users = new UserManager(this, this.config.cacheConfig);
+        this.#content = new ContentManager(this, this.config.cacheConfig);
+        this.#feeds = new FeedManager(this);
+        this.#app = new AppManager(this);
 
-		this.instance.interceptors.request.use((config) => {
-			config.headers.set(this.config.headers);
-			config.headers.Authorization ??= this.authorization;
-			return config;
-		});
+        this.instance.interceptors.request.use((config) => {
+            config.headers.set(this.config.headers);
+            config.headers.Authorization ??= this.authorization;
+            return config;
+        });
 
-		this.instance.interceptors.response.use(
-			(onSuccess) => onSuccess,
-			(onFail) => {
-				if (!this.util.isAxiosError(onFail) || !onFail.response) throw onFail;
-				if (!this.util.isAPIError(onFail.response.data)) throw onFail;
-				if (iFunnyError.isRawCaptchaError(this, onFail.response.data)) {
-					throw new CaptchaError(this, onFail.response.data);
-				}
-				throw new iFunnyError(this, onFail.response.data);
-			}
-		);
-	}
+        this.instance.interceptors.response.use(
+            (onSuccess) => onSuccess,
+            (onFail) => {
+                if (!this.util.isAxiosError(onFail) || !onFail.response)
+                    throw onFail;
+                if (!this.util.isAPIError(onFail.response.data)) throw onFail;
+                if (iFunnyError.isRawCaptchaError(this, onFail.response.data)) {
+                    throw new CaptchaError(this, onFail.response.data);
+                }
+                throw new iFunnyError(this, onFail.response.data);
+            },
+        );
+    }
 
-	/**
-	 * Utility class for the client
-	 */
-	public get util(): Util {
-		return this.#util;
-	}
+    /**
+     * Utility class for the client
+     */
+    public get util(): Util {
+        return this.#util;
+    }
 
-	/**
-	 * Basic token used by the client.\
-	 * If not set in constructor, one was generated
-	 */
-	public get basic(): string {
-		return (this.config.basic ||= this.util.createBasicAuth({
-			clientId: this.config.clientId,
-			clientSecret: this.config.clientSecret,
-			length: this.config.basicLength,
-		}));
-	}
+    /**
+     * Basic token used by the client.\
+     * If not set in constructor, one was generated
+     */
+    public get basic(): string {
+        return (this.config.basic ||= this.util.createBasicAuth({
+            clientId: this.config.clientId,
+            clientSecret: this.config.clientSecret,
+            length: this.config.basicLength,
+        }));
+    }
 
-	/**
-	 * Sets the basic token for the Client. Must be a string
-	 */
-	public set basic(value: string) {
-		this.config.basic = value;
-	}
+    /**
+     * Sets the basic token for the Client. Must be a string
+     */
+    public set basic(value: string) {
+        this.config.basic = value;
+    }
 
-	/**
-	 * Prime the Client's basic token
-	 * @returns The Client's basic token
-	 */
-	public async primeBasic(): Promise<string>;
-	/**
-	 * Primes a basic token without updating the Client config. This takes ~15 seconds
-	 * @param basic Basic token to prime
-	 * @returns Basic token being primed
-	 */
-	public async primeBasic(basic: string): Promise<string>;
-	public async primeBasic(basic?: string): Promise<string> {
-		await this.instance.get(Endpoints.counters, {
-			headers: { Authorization: `Basic ${(basic ??= this.basic)}` },
-		});
-		// ? Takes ~15 seconds to prime the basic token
-		await this.util.sleep(1000 * 15);
-		return basic;
-	}
+    /**
+     * Prime the Client's basic token
+     * @returns The Client's basic token
+     */
+    public async primeBasic(): Promise<string>;
+    /**
+     * Primes a basic token without updating the Client config. This takes ~15 seconds
+     * @param basic Basic token to prime
+     * @returns Basic token being primed
+     */
+    public async primeBasic(basic: string): Promise<string>;
+    public async primeBasic(basic?: string): Promise<string> {
+        await this.instance.get(Endpoints.counters, {
+            headers: { Authorization: `Basic ${(basic ??= this.basic)}` },
+        });
+        // ? Takes ~15 seconds to prime the basic token
+        await this.util.sleep(1000 * 15);
+        return basic;
+    }
 
-	/**
-	 * The bearer token for the client
-	 */
-	public get bearer(): If<Authorized, string, null> {
-		return this.config.bearer as If<Authorized, string, null>;
-	}
+    /**
+     * The bearer token for the client
+     */
+    public get bearer(): If<Authorized, string, null> {
+        return this.config.bearer as If<Authorized, string, null>;
+    }
 
-	/**
-	 * Sets the bearer token for the client. If set to null, the client will not use a bearer token.
-	 */
-	public set bearer(value: string | null) {
-		this.config.bearer = value || null;
-		this.instance.defaults.headers.common.Authorization = this.isAuthorized()
-			? `Bearer ${this.bearer}`
-			: `Basic ${this.basic}`;
-	}
+    /**
+     * Sets the bearer token for the client. If set to null, the client will not use a bearer token.
+     */
+    public set bearer(value: string | null) {
+        this.config.bearer = value || null;
+        this.instance.defaults.headers.common.Authorization =
+            this.isAuthorized()
+                ? `Bearer ${this.bearer}`
+                : `Basic ${this.basic}`;
+    }
 
-	/**
-	 * The authorization string used for requests
-	 */
-	public get authorization(): string {
-		return this.bearer ? `Bearer ${this.bearer}` : `Basic ${this.basic}`;
-	}
+    /**
+     * The authorization string used for requests
+     */
+    public get authorization(): string {
+        return this.bearer ? `Bearer ${this.bearer}` : `Basic ${this.basic}`;
+    }
 
-	/**
-	 * Is the client using a bearer token to make requests?
-	 */
-	public isAuthorized(): this is Client<true> {
-		return !!this.bearer;
-	}
+    /**
+     * Is the client using a bearer token to make requests?
+     */
+    public isAuthorized(): this is Client<true> {
+        return !!this.bearer;
+    }
 
-	/**
-	 * Updates the Client's payload
-	 * @returns The Client instance
-	 */
-	public async fetch(): Promise<this> {
-		if (!this.isAuthorized()) {
-			throw new Error(
-				"Client is not authorized with a bearer token. Please generate one with Client#login"
-			);
-		}
+    /**
+     * Updates the Client's payload
+     * @returns The Client instance
+     */
+    public async fetch(): Promise<this> {
+        if (!this.isAuthorized()) {
+            throw new Error(
+                "Client is not authorized with a bearer token. Please generate one with Client#login",
+            );
+        }
 
-		const response = await this.instance.get<Success<APIClientUser>>(
-			Endpoints.account
-		);
+        const response = await this.instance.get<Success<APIClientUser>>(
+            Endpoints.account,
+        );
 
-		const data = response.data;
-		this.payload = data.data;
-		return this;
-	}
+        const data = response.data;
+        this.payload = data.data;
+        return this;
+    }
 
-	/**
-	 * The client's user manager
-	 */
-	public get users(): UserManager {
-		return this.#users;
-	}
+    /**
+     * The client's user manager
+     */
+    public get users(): UserManager {
+        return this.#users;
+    }
 
-	/**
-	 * The content feeds for the Client
-	 */
-	public get feeds(): FeedManager {
-		return this.#feeds;
-	}
+    /**
+     * The content feeds for the Client
+     */
+    public get feeds(): FeedManager {
+        return this.#feeds;
+    }
 
-	/**
-	 * The Client's Content manager
-	 */
-	public get content(): ContentManager {
-		return this.#content;
-	}
+    /**
+     * The Client's Content manager
+     */
+    public get content(): ContentManager {
+        return this.#content;
+    }
 
-	/**
-	 * Manage the client's application data like settings or features
-	 */
-	public get app(): AppManager {
-		return this.#app;
-	}
+    /**
+     * Manage the client's application data like settings or features
+     */
+    public get app(): AppManager {
+        return this.#app;
+    }
 
-	/**
-	 * Asynchronously gets the authorized user or null if not authorized.
-	 * @returns A promise that resolves to the client user or null.
-	 */
-	public async user(): Promise<If<Authorized, User, null>> {
-		if (!this.isAuthorized()) {
-			return null as If<Authorized, User, null>;
-		}
-		await this.fetch();
-		return (this.#user ??= await this.users.fetch(this.id)) as If<
-			Authorized,
-			User,
-			null
-		>;
-	}
+    /**
+     * Asynchronously gets the authorized user or null if not authorized.
+     * @returns A promise that resolves to the client user or null.
+     */
+    public async user(): Promise<If<Authorized, User, null>> {
+        if (!this.isAuthorized()) {
+            return null as If<Authorized, User, null>;
+        }
+        await this.fetch();
+        return (this.#user ??= await this.users.fetch(this.id)) as If<
+            Authorized,
+            User,
+            null
+        >;
+    }
 
-	/**
-	 * Logs in using the stored bearer token.\
-	 * Does NOT Generate a new bearer token
-	 */
-	public async login(): Promise<this>;
-	/**
-	 * Logs the Client in an generates a new Bearer token.\
-	 * If a bearer token is stored, these are ignored
-	 * @param email The email to log in with
-	 * @param password The password to log in with
-	 */
-	public async login(email: string, password: string): Promise<this>;
-	public async login(email?: string, password?: string): Promise<this> {
-		if (this.isAuthorized()) {
-			return await this.fetch();
-		}
+    /**
+     * Logs in using the stored bearer token.\
+     * Does NOT Generate a new bearer token
+     */
+    public async login(): Promise<this>;
+    /**
+     * Logs the Client in an generates a new Bearer token.\
+     * If a bearer token is stored, these are ignored
+     * @param email The email to log in with
+     * @param password The password to log in with
+     */
+    public async login(email: string, password: string): Promise<this>;
+    public async login(email?: string, password?: string): Promise<this> {
+        if (this.isAuthorized()) {
+            return await this.fetch();
+        }
 
-		if (!email || !password) {
-			throw new TypeError(
-				"email and password are required if a bearer hasn't been set"
-			);
-		}
-		const auth = `Basic ${this.basic}`;
-		const data = new FormData();
-		data.append("grant_type", "password");
-		data.append("username", email);
-		data.append("password", password);
-		const response = await this.instance.post<RESTAPIOauth2LoginSuccess>(
-			Endpoints.token,
-			data,
-			{
-				headers: Object.assign(
-					{
-						accept: "application/json",
-						applicationstate: 1,
-						authorization: auth,
-						connection: "Keep-Alive",
-						"content-type": "application/x-www-form-urlencoded",
-					},
-					data.getHeaders()
-				),
-			}
-		);
-		this.bearer = response.data.access_token;
-		return await this.fetch();
-	}
+        if (!email || !password) {
+            throw new TypeError(
+                "email and password are required if a bearer hasn't been set",
+            );
+        }
+        const auth = `Basic ${this.basic}`;
+        const data = new FormData();
+        data.append("grant_type", "password");
+        data.append("username", email);
+        data.append("password", password);
+        const response = await this.instance.post<RESTAPIOauth2LoginSuccess>(
+            Endpoints.token,
+            data,
+            {
+                headers: Object.assign(
+                    {
+                        accept: "application/json",
+                        applicationstate: 1,
+                        authorization: auth,
+                        connection: "Keep-Alive",
+                        "content-type": "application/x-www-form-urlencoded",
+                    },
+                    data.getHeaders(),
+                ),
+            },
+        );
+        this.bearer = response.data.access_token;
+        return await this.fetch();
+    }
 
-	/**
-	 * Signs up for an iFunny account.
-	 * @param options.nick The nick of the account to sign up with. Checks if the nick is taken.
-	 * @param options.email The email to sign up with. Checks if the email is taken.
-	 * @param options.password The password to sign up with
-	 * @param options.acceptMailOffers Should the Client sign up for the mailing list. Never set this to true.
-	 * @param options.login Should the client login after sign up? (Default: true)
-	 * @returns The instance of the client
-	 */
-	public async signUp(options: SignUpOptions): Promise<this> {
-		const data = new FormData();
-		data.append("reg_type", "pwd");
-		data.append("nick", options.nick);
-		data.append("email", options.email);
-		data.append("password", options.password);
-		data.append("accept_mailing", !!options.acceptMailing ? "1" : "0");
+    /**
+     * Signs up for an iFunny account.
+     * @param options.nick The nick of the account to sign up with. Checks if the nick is taken.
+     * @param options.email The email to sign up with. Checks if the email is taken.
+     * @param options.password The password to sign up with
+     * @param options.acceptMailing Should the Client sign up for the mailing list. Never set this to true.
+     * @param options.login Should the client login after sign up? (Default: true)
+     * @returns The instance of the client
+     */
+    public async signUp(options: SignUpOptions): Promise<this> {
+        const data = new FormData();
+        data.append("reg_type", "pwd");
+        data.append("nick", options.nick);
+        data.append("email", options.email);
+        data.append("password", options.password);
+        data.append("accept_mailing", options.acceptMailing ? "1" : "0");
 
-		const response = await this.instance.post<RESTAPISignUpSuccess>(
-			Endpoints.user(),
-			data,
-			{ headers: data.getHeaders() }
-		);
+        const response = await this.instance.post<RESTAPISignUpSuccess>(
+            Endpoints.user(),
+            data,
+            { headers: data.getHeaders() },
+        );
 
-		this.payload.id = response.data.data.id;
-		if (options.login ?? true) {
-			return await this.login(options.email, options.password);
-		}
+        this.payload.id = response.data.data.id;
+        if (options.login ?? true) {
+            return await this.login(options.email, options.password);
+        }
 
-		return this;
-	}
+        return this;
+    }
 
-	protected get<K extends keyof APIClientUser>(
-		key: K
-	): If<Authorized, APIClientUser[K], null> {
-		return (this.payload?.[key] ?? null) as If<
-			Authorized,
-			APIClientUser[K],
-			null
-		>;
-	}
+    protected get<K extends keyof APIClientUser>(
+        key: K,
+    ): If<Authorized, APIClientUser[K], null> {
+        return (this.payload?.[key] ?? null) as If<
+            Authorized,
+            APIClientUser[K],
+            null
+        >;
+    }
 
-	public get about() {
-		return this.get("about");
-	}
+    public get about() {
+        return this.get("about");
+    }
 
-	public get id() {
-		return this.get("id");
-	}
+    public get id() {
+        return this.get("id");
+    }
 }
 
 export default Client;

--- a/src/errors/CaptchaError.ts
+++ b/src/errors/CaptchaError.ts
@@ -1,8 +1,8 @@
 import { Client } from "../client/Client";
 import { iFunnyError } from "./iFunnyError";
 import {
-	RESTAPICaptchaType,
-	RESTAPIErrorCaptchaRequired,
+    RESTAPICaptchaType,
+    RESTAPIErrorCaptchaRequired,
 } from "@ifunny/ifunny-api-types";
 
 /**
@@ -11,27 +11,27 @@ import {
  * @extends iFunnyError<RESTAPIErrorCaptchaRequired>
  */
 export class CaptchaError extends iFunnyError<RESTAPIErrorCaptchaRequired> {
-	/**
-	 * @param client Client instance
-	 * @param error Raw Error returned by the API
-	 */
-	public constructor(client: Client, error: RESTAPIErrorCaptchaRequired) {
-		super(client, error);
-	}
+    /**
+     * @param client Client instance
+     * @param error Raw Error returned by the API
+     */
+    public constructor(client: Client, error: RESTAPIErrorCaptchaRequired) {
+        super(client, error);
+    }
 
-	/**
-	 * The type of the captcha
-	 */
-	public get type(): RESTAPICaptchaType {
-		return this.raw.data.type;
-	}
+    /**
+     * The type of the captcha
+     */
+    public get type(): RESTAPICaptchaType {
+        return this.raw.data.type;
+    }
 
-	/**
-	 * URL to open to solve the captcha.
-	 */
-	public get captchaUrl(): string {
-		return this.raw.data.captcha_url;
-	}
+    /**
+     * URL to open to solve the captcha.
+     */
+    public get captchaUrl(): string {
+        return this.raw.data.captcha_url;
+    }
 }
 
 export default CaptchaError;

--- a/src/errors/iFunnyError.ts
+++ b/src/errors/iFunnyError.ts
@@ -1,8 +1,8 @@
 import {
-	IFUNNY_ERRORS,
-	RESTAPIErrorCaptchaRequired,
-	RESTAPIErrorResponse,
-	RESTAPIiFunnyError,
+    IFUNNY_ERRORS,
+    RESTAPIErrorCaptchaRequired,
+    RESTAPIErrorResponse,
+    RESTAPIiFunnyError,
 } from "@ifunny/ifunny-api-types";
 import { CaptchaError } from "./CaptchaError";
 import { Client } from "../client/Client";
@@ -13,109 +13,109 @@ import { Client } from "../client/Client";
  * @template APIError - The type of the error response returned by the iFunny REST API.
  */
 export class iFunnyError<
-	APIError extends RESTAPIErrorResponse = RESTAPIErrorResponse
+    APIError extends RESTAPIErrorResponse = RESTAPIErrorResponse,
 > extends Error {
-	#error: APIError;
-	readonly #client: Client;
+    #error: APIError;
+    readonly #client: Client;
 
-	/**
-	 * @param client Client instance attached to the Error
-	 * @param error The error thrown by the API
-	 */
-	public constructor(client: Client, error: APIError) {
-		super(error.error_description);
-		this.#client = client;
-		if (iFunnyError.isRawCaptchaError(client, error)) {
-			this.message += ": " + error.data.captcha_url;
-		}
-		this.#error = error;
+    /**
+     * @param client Client instance attached to the Error
+     * @param error The error thrown by the API
+     */
+    public constructor(client: Client, error: APIError) {
+        super(error.error_description);
+        this.#client = client;
+        if (iFunnyError.isRawCaptchaError(client, error)) {
+            this.message += ": " + error.data.captcha_url;
+        }
+        this.#error = error;
 
-		Error.captureStackTrace?.(this, iFunnyError);
-	}
+        Error.captureStackTrace?.(this, iFunnyError);
+    }
 
-	/**
-	 * Client instance that threw the error
-	 */
-	public get client(): Client {
-		return this.#client;
-	}
+    /**
+     * Client instance that threw the error
+     */
+    public get client(): Client {
+        return this.#client;
+    }
 
-	/**
-	 * The error code for the error
-	 */
-	public get code(): RESTAPIiFunnyError {
-		return this.raw.error;
-	}
+    /**
+     * The error code for the error
+     */
+    public get code(): RESTAPIiFunnyError {
+        return this.raw.error;
+    }
 
-	/**
-	 * Status code returned by the API
-	 */
-	public get status() {
-		return this.raw.status;
-	}
+    /**
+     * Status code returned by the API
+     */
+    public get status() {
+        return this.raw.status;
+    }
 
-	/**
-	 * Raw error returned by the API
-	 */
-	public get raw() {
-		return this.#error;
-	}
+    /**
+     * Raw error returned by the API
+     */
+    public get raw() {
+        return this.#error;
+    }
 
-	/**
-	 * The name of the error
-	 */
-	public override get name() {
-		return `${this.constructor.name} - ${this.code} [${this.status}]`;
-	}
+    /**
+     * The name of the error
+     */
+    public override get name() {
+        return `${this.constructor.name} - ${this.code} [${this.status}]`;
+    }
 
-	/**
-	 * Type guards an object into an iFunnyError
-	 * @param error Object to type guard
-	 * @returns error is iFunnyError
-	 */
-	public static isiFunnyError(error: unknown): error is iFunnyError {
-		return error instanceof iFunnyError;
-	}
+    /**
+     * Type guards an object into an iFunnyError
+     * @param error Object to type guard
+     * @returns error is iFunnyError
+     */
+    public static isiFunnyError(error: unknown): error is iFunnyError {
+        return error instanceof iFunnyError;
+    }
 
-	/**
-	 * Type guards an object into captcha like error
-	 * @param client Client instance to use util class for
-	 * @param error Error response from AxiosError#response#data
-	 * @internal
-	 */
-	static isRawCaptchaError(
-		client: Client,
-		error: unknown
-	): error is RESTAPIErrorCaptchaRequired {
-		if (!client.util.isAPIError(error)) return false;
-		if (error.error !== IFUNNY_ERRORS.CAPTCHA_REQUIRED) return false;
-		if (!client.util.hasProperty(error, "data")) return false;
-		if (!client.util.hasProperty(error.data, "captcha_url")) return false;
-		if (!client.util.hasProperty(error.data, "type")) return false;
-		if (typeof error.data.type !== "string") return false;
-		if (typeof error.data.captcha_url !== "string") return false;
-		return true;
-	}
+    /**
+     * Type guards an object into captcha like error
+     * @param client Client instance to use util class for
+     * @param error Error response from AxiosError#response#data
+     * @internal
+     */
+    static isRawCaptchaError(
+        client: Client,
+        error: unknown,
+    ): error is RESTAPIErrorCaptchaRequired {
+        if (!client.util.isAPIError(error)) return false;
+        if (error.error !== IFUNNY_ERRORS.CAPTCHA_REQUIRED) return false;
+        if (!client.util.hasProperty(error, "data")) return false;
+        if (!client.util.hasProperty(error.data, "captcha_url")) return false;
+        if (!client.util.hasProperty(error.data, "type")) return false;
+        if (typeof error.data.type !== "string") return false;
+        if (typeof error.data.captcha_url !== "string") return false;
+        return true;
+    }
 
-	/**
-	 * Type guards an object into CaptchaError
-	 * @param error Error to validate
-	 * @returns error is CaptchaError
-	 */
-	public static isCaptchaError(error: unknown): error is CaptchaError {
-		return error instanceof CaptchaError;
-	}
+    /**
+     * Type guards an object into CaptchaError
+     * @param error Error to validate
+     * @returns error is CaptchaError
+     */
+    public static isCaptchaError(error: unknown): error is CaptchaError {
+        return error instanceof CaptchaError;
+    }
 
-	/**
-	 * Type Guards this Error into CaptchaError
-	 */
-	public isCaptchaError(): this is CaptchaError;
-	/**
-	 * Type Guards error into CaptchaError
-	 * @param error Error to Type Guard
-	 */
-	public isCaptchaError(error: unknown): error is CaptchaError;
-	public isCaptchaError(error?: unknown) {
-		return iFunnyError.isCaptchaError(error ?? this);
-	}
+    /**
+     * Type Guards this Error into CaptchaError
+     */
+    public isCaptchaError(): this is CaptchaError;
+    /**
+     * Type Guards error into CaptchaError
+     * @param error Error to Type Guard
+     */
+    public isCaptchaError(error: unknown): error is CaptchaError;
+    public isCaptchaError(error?: unknown) {
+        return iFunnyError.isCaptchaError(error ?? this);
+    }
 }

--- a/src/errors/mod.ts
+++ b/src/errors/mod.ts
@@ -1,0 +1,2 @@
+export { CaptchaError } from "./CaptchaError";
+export { iFunnyError } from "./iFunnyError";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,6 @@
 export { BaseClient } from "./client/BaseClient";
 export { Client, default } from "./client/Client";
 
-// ! Errors
-export { CaptchaError } from "./errors/CaptchaError";
-export { iFunnyError } from "./errors/iFunnyError";
-
 // ? Structs
 export { Ban } from "./structures/Ban";
 export { BanSmall } from "./structures/BanSmall";
@@ -18,4 +14,10 @@ export { News } from "./structures/News";
 export { SimpleUser } from "./structures/SimpleUser";
 export { Thumbnail } from "./structures/Thumbnail";
 export { User } from "./structures/User";
-export { Util } from "./utils/Util";
+
+// ? Sub Modules
+export * as Managers from "./managers/mod";
+export { Util, Types, Constants } from "./utils/mod";
+
+// ! Errors
+export * as Errors from "./errors/mod";

--- a/src/managers/AppManager.ts
+++ b/src/managers/AppManager.ts
@@ -1,10 +1,10 @@
 import {
-	APIAppPrivacy,
-	APIAppSettings,
-	APICounters,
-	Endpoints,
-	RESTAPICountersResponse,
-	RESTAPISuccessResponse,
+    APIAppPrivacy,
+    APIAppSettings,
+    APICounters,
+    Endpoints,
+    RESTAPICountersResponse,
+    RESTAPISuccessResponse,
 } from "@ifunny/ifunny-api-types";
 import Client from "../client/Client";
 
@@ -12,54 +12,56 @@ import Client from "../client/Client";
  * Manages misc data from the app.
  */
 export class AppManager {
-	readonly #client: Client;
-	/**
-	 * @param client Client instance
-	 */
-	constructor(client: Client) {
-		this.#client = client;
-	}
+    readonly #client: Client;
+    /**
+     * @param client Client instance
+     */
+    constructor(client: Client) {
+        this.#client = client;
+    }
 
-	/**
-	 * Client instance attached to the manager
-	 */
-	public get client(): Client {
-		return this.#client;
-	}
+    /**
+     * Client instance attached to the manager
+     */
+    public get client(): Client {
+        return this.#client;
+    }
 
-	/**
-	 * Fetches the counter data for the Client.
-	 * @returns App counters for the API
-	 */
-	public async counters(): Promise<APICounters> {
-		return (
-			await this.client.instance.get<RESTAPICountersResponse>(Endpoints.counters)
-		).data.data;
-	}
+    /**
+     * Fetches the counter data for the Client.
+     * @returns App counters for the API
+     */
+    public async counters(): Promise<APICounters> {
+        return (
+            await this.client.instance.get<RESTAPICountersResponse>(
+                Endpoints.counters,
+            )
+        ).data.data;
+    }
 
-	/**
-	 * Fetches App settings
-	 * @returns App settings configuration
-	 */
-	public async settings(): Promise<APIAppSettings> {
-		return (
-			await this.client.instance.get<RESTAPISuccessResponse<APIAppSettings>>(
-				Endpoints.settings
-			)
-		).data.data;
-	}
+    /**
+     * Fetches App settings
+     * @returns App settings configuration
+     */
+    public async settings(): Promise<APIAppSettings> {
+        return (
+            await this.client.instance.get<
+                RESTAPISuccessResponse<APIAppSettings>
+            >(Endpoints.settings)
+        ).data.data;
+    }
 
-	/**
-	 * Fetches App privacy
-	 * @returns The App's privacy configuration
-	 */
-	public async privacy(): Promise<APIAppPrivacy> {
-		return (
-			await this.client.instance.get<RESTAPISuccessResponse<APIAppPrivacy>>(
-				Endpoints.privacy
-			)
-		).data.data;
-	}
+    /**
+     * Fetches App privacy
+     * @returns The App's privacy configuration
+     */
+    public async privacy(): Promise<APIAppPrivacy> {
+        return (
+            await this.client.instance.get<
+                RESTAPISuccessResponse<APIAppPrivacy>
+            >(Endpoints.privacy)
+        ).data.data;
+    }
 }
 
 export default AppManager;

--- a/src/managers/CachedManager.ts
+++ b/src/managers/CachedManager.ts
@@ -8,69 +8,75 @@ import { ICachingOptions } from "node-ts-cache";
  * @template Holds
  */
 export class CachedManager<Holds extends DataStructure> {
-	/**
-	 * The client this manager is attached to
-	 */
-	public readonly client: Client;
+    /**
+     * The client this manager is attached to
+     */
+    public readonly client: Client;
 
-	/**
-	 * The cache of items for this manager
-	 */
-	readonly #cache: Cache<Holds>;
+    /**
+     * The cache of items for this manager
+     */
+    readonly #cache: Cache<Holds>;
 
-	/**
-	 * The data structure belonging to this manager
-	 */
-	readonly #holds: Holds;
+    /**
+     * The data structure belonging to this manager
+     */
+    readonly #holds: Holds;
 
-	/**
-	 * @param client Client attached to the CachedManager
-	 * @param holds The class constructor the manager uses
-	 * @param cacheConfig Config for the cache to use
-	 */
-	public constructor(client: Client, holds: Holds, cacheConfig: ICachingOptions) {
-		this.client = client;
-		this.#cache = new Cache(holds, cacheConfig);
-		this.#holds = holds;
-	}
+    /**
+     * @param client Client attached to the CachedManager
+     * @param holds The class constructor the manager uses
+     * @param cacheConfig Config for the cache to use
+     */
+    public constructor(
+        client: Client,
+        holds: Holds,
+        cacheConfig: ICachingOptions,
+    ) {
+        this.client = client;
+        this.#cache = new Cache(holds, cacheConfig);
+        this.#holds = holds;
+    }
 
-	/**
-	 * The cache of users
-	 */
-	public get cache(): Cache<Holds> {
-		return this.#cache;
-	}
+    /**
+     * The cache of users
+     */
+    public get cache(): Cache<Holds> {
+        return this.#cache;
+    }
 
-	/**
-	 * The class this manager holds
-	 */
-	public get holds(): Holds {
-		return this.#holds;
-	}
+    /**
+     * The class this manager holds
+     */
+    public get holds(): Holds {
+        return this.#holds;
+    }
 
-	/**
-	 * Resolves an id or instance into an instance
-	 * @param idOrInstance Id of the instance or the instance itself
-	 */
-	public async resolve(
-		idOrInstance: string | InstanceType<Holds>
-	): Promise<InstanceType<Holds> | null> {
-		if (idOrInstance instanceof this.#holds) return idOrInstance;
-		if (typeof idOrInstance === "string") {
-			return (await this.#cache.get(idOrInstance)) ?? null;
-		}
-		return null;
-	}
+    /**
+     * Resolves an id or instance into an instance
+     * @param idOrInstance Id of the instance or the instance itself
+     */
+    public async resolve(
+        idOrInstance: string | InstanceType<Holds>,
+    ): Promise<InstanceType<Holds> | null> {
+        if (idOrInstance instanceof this.#holds) return idOrInstance;
+        if (typeof idOrInstance === "string") {
+            return (await this.#cache.get(idOrInstance)) ?? null;
+        }
+        return null;
+    }
 
-	/**
-	 * Resolves an id or instance into an id
-	 * @param idOrInstance Id of the instance of the instance itself
-	 */
-	public resolveId(idOrInstance: string | InstanceType<Holds>): string | null {
-		if (idOrInstance instanceof this.#holds) return idOrInstance.id;
-		if (typeof idOrInstance === "string") return idOrInstance;
-		return null;
-	}
+    /**
+     * Resolves an id or instance into an id
+     * @param idOrInstance Id of the instance of the instance itself
+     */
+    public resolveId(
+        idOrInstance: string | InstanceType<Holds>,
+    ): string | null {
+        if (idOrInstance instanceof this.#holds) return idOrInstance.id;
+        if (typeof idOrInstance === "string") return idOrInstance;
+        return null;
+    }
 }
 
 export default CachedManager;

--- a/src/managers/ContentManager.ts
+++ b/src/managers/ContentManager.ts
@@ -1,9 +1,9 @@
 import {
-	APIFeedFrom,
-	Endpoints,
-	IFUNNY_ERRORS,
-	RESTAPIContentResponse,
-	RESTAPIStatusCode,
+    APIFeedFrom,
+    Endpoints,
+    IFUNNY_ERRORS,
+    RESTAPIContentResponse,
+    RESTAPIStatusCode,
 } from "@ifunny/ifunny-api-types";
 import { CachedManager } from "./CachedManager";
 import { Client } from "../client/Client";
@@ -16,75 +16,78 @@ import { ICachingOptions } from "node-ts-cache";
  * @extends CachedManager<Content>
  */
 export class ContentManager extends CachedManager<typeof Content> {
-	/**
-	 * @param client Client instance
-	 * @param cacheConfig Config to use for Caching
-	 */
-	public constructor(client: Client, cacheConfig: ICachingOptions) {
-		super(client, Content, cacheConfig);
-	}
+    /**
+     * @param client Client instance
+     * @param cacheConfig Config to use for Caching
+     */
+    public constructor(client: Client, cacheConfig: ICachingOptions) {
+        super(client, Content, cacheConfig);
+    }
 
-	/**
-	 * Fetches Content by its Id
-	 * @param id Id of the content
-	 * @param cached Should we return the Cached item? (Default: `true`)
-	 * @returns Content
-	 */
-	public async fetch(
-		contentOrId: Content | string,
-		cached: boolean = true
-	): Promise<Content | null> {
-		try {
-			let content = await this.resolve(contentOrId);
-			if (content && cached) return content;
+    /**
+     * Fetches Content
+     * @param contentOrId Id of the content
+     * @param cached Should we return the Cached item? (Default: `true`)
+     * @returns Content
+     */
+    public async fetch(
+        contentOrId: Content | string,
+        cached: boolean = true,
+    ): Promise<Content | null> {
+        try {
+            if (cached) {
+                const content = await this.resolve(contentOrId);
+                if (content !== null) return content;
+            }
 
-			const id = this.resolveId(contentOrId);
+            const id = this.resolveId(contentOrId);
 
-			const { data } = await this.client.instance.get<RESTAPIContentResponse>(
-				`content/${id}`
-			);
+            const { data } =
+                await this.client.instance.get<RESTAPIContentResponse>(
+                    `content/${id}`,
+                );
 
-			content = new Content(this.client, data.data);
-			this.cache.set(content.id, content, this.cache.config);
+            const content = new Content(this.client, data.data);
+            this.cache.set(content.id, content, this.cache.config);
 
-			return content;
-		} catch (error) {
-			if (!iFunnyError.isiFunnyError(error)) throw error;
+            return content;
+        } catch (error) {
+            if (!iFunnyError.isiFunnyError(error)) throw error;
 
-			if (error.code === IFUNNY_ERRORS.NOT_FOUND) {
-				return null;
-			} else throw error;
-		}
-	}
+            if (error.code === IFUNNY_ERRORS.NOT_FOUND) {
+                return null;
+            } else throw error;
+        }
+    }
 
-	/**
-	 * Mark content as read.
-	 * @param content Content to mark as read
-	 * @param from Where the content was marked as read.
-	 */
-	public async markAsRead(
-		content: Content | string | (Content | string)[],
-		from?: APIFeedFrom
-	): Promise<boolean> {
-		const items = Array.isArray(content)
-			? content
-					.map((c) => {
-						if (typeof c === "string") return c;
-						return c.id;
-					})
-					.join(",")
-			: content instanceof Content
-			? content.id
-			: content;
+    /**
+     * Mark content as read.
+     * @param content Content to mark as read
+     * @param from Where the content was marked as read.
+     */
+    public async markAsRead(
+        content: Content | string | (Content | string)[],
+        from?: APIFeedFrom,
+    ): Promise<boolean> {
+        const items = Array.isArray(content)
+            ? content
+                  .map((c) => {
+                      if (typeof c === "string") return c;
+                      return c.id;
+                  })
+                  .join(",")
+            : content instanceof Content
+              ? content.id
+              : content;
 
-		const response = await this.client.instance.request<RESTAPIStatusCode>({
-			method: "PUT",
-			url: Endpoints.reads(items),
-			params: new URLSearchParams({ from: from as string }),
-		});
+        const response = await this.client.instance.request<RESTAPIStatusCode>({
+            method: "PUT",
+            url: Endpoints.reads(items),
+            params: new URLSearchParams({ from: from as string }),
+        });
 
-		return response.data.status == 200;
-	}
+        return response.data.status == 200;
+    }
 }
 
 export default ContentManager;

--- a/src/managers/FeedManager.ts
+++ b/src/managers/FeedManager.ts
@@ -5,54 +5,63 @@ import { Feed } from "../structures/Feed";
  * Handles different feeds for the Client
  */
 export class FeedManager {
-	/**
-	 * Client attached to the FeedManager
-	 */
-	readonly #client: Client;
-	readonly #features: Feed;
-	readonly #collective: Feed;
-	readonly #home: Feed;
+    /**
+     * {@link Client} attached to the FeedManager
+     */
+    readonly #client: Client;
+    readonly #features: Feed;
+    readonly #collective: Feed;
+    readonly #home: Feed;
 
-	/**
-	 * @param client Client instance
-	 */
-	public constructor(client: Client) {
-		this.#client = client;
-		this.#features = new Feed(this.#client, Feed.Types.FEATURES);
-		this.#collective = new Feed(this.#client, Feed.Types.COLLECTIVE);
-		this.#home = new Feed(this.#client, Feed.Types.HOME);
-	}
+    /**
+     * @param client Client instance
+     */
+    public constructor(client: Client) {
+        this.#client = client;
+        this.#features = new Feed(this.#client, Feed.Types.FEATURES);
+        this.#collective = new Feed(this.#client, Feed.Types.COLLECTIVE);
+        this.#home = new Feed(this.#client, Feed.Types.HOME);
+    }
 
-	/**
-	 * The featured feed
-	 */
-	public get features(): Feed {
-		return this.#features;
-	}
+    /**
+     * The {@link Client} instance
+     */
+    public get client(): Client {
+        return this.#client;
+    }
 
-	/**
-	 * The collective feed
-	 */
-	public get collective(): Feed {
-		return this.#collective;
-	}
+    /**
+     * The featured feed
+     */
+    public get features(): Feed {
+        return this.#features;
+    }
 
-	/**
-	 * The subscriptions feed
-	 * @alias home
-	 */
-	public get subscriptions(): Feed {
-		return this.home;
-	}
+    /**
+     * The collective feed
+     */
+    public get collective(): Feed {
+        return this.#collective;
+    }
 
-	/**
-	 * The home feed
-	 * @alias subscriptions
-	 */
-	public get home(): Feed {
-		// This is the url so I included it
-		return this.#home;
-	}
+    /**
+     * The subscriptions feed
+     *
+     * Alias for {@link home}
+     */
+    public get subscriptions(): Feed {
+        return this.home;
+    }
+
+    /**
+     * The home feed
+     *
+     * Alias for {@link subscriptions}
+     */
+    public get home(): Feed {
+        // This is the url so I included it
+        return this.#home;
+    }
 }
 
 export default FeedManager;

--- a/src/managers/UserManager.ts
+++ b/src/managers/UserManager.ts
@@ -1,8 +1,8 @@
 import {
-	APIUserProfile,
-	Endpoints,
-	IFUNNY_ERRORS,
-	RESTAPISuccessResponse as Success,
+    APIUserProfile,
+    Endpoints,
+    IFUNNY_ERRORS,
+    RESTAPISuccessResponse as Success,
 } from "@ifunny/ifunny-api-types";
 import { CachedManager } from "./CachedManager";
 import { Client } from "../client/Client";
@@ -15,76 +15,84 @@ import { User } from "../structures/User";
  * @extends CachedManager<User>
  */
 export class UserManager extends CachedManager<typeof User> {
-	/**
-	 * @param client Client instance attached to the UserManager
-	 */
-	public constructor(client: Client, cacheConfig: ICachingOptions) {
-		super(client, User, cacheConfig);
-	}
+    /**
+     * @param client Client instance attached to the UserManager
+     */
+    public constructor(client: Client, cacheConfig: ICachingOptions) {
+        super(client, User, cacheConfig);
+    }
 
-	/**
-	 * Checks if a nick is available or if it's taken by another user\
-	 * It's a good idea to check this before signing up or changing your nick
-	 * @param nick Nick to check availability of
-	 */
-	public async isNickAvailable(nick: string): Promise<boolean> {
-		const { data } = await this.client.instance.get(Endpoints.nicksAvailable, {
-			params: {
-				nick,
-			},
-		});
+    /**
+     * Checks if a nick is available or if it's taken by another user\
+     * It's a good idea to check this before signing up or changing your nick
+     * @param nick Nick to check availability of
+     */
+    public async isNickAvailable(nick: string): Promise<boolean> {
+        const { data } = await this.client.instance.get(
+            Endpoints.nicksAvailable,
+            {
+                params: {
+                    nick,
+                },
+            },
+        );
 
-		return data.data.available;
-	}
+        return data.data.available;
+    }
 
-	/**
-	 * Checks if an email is available or if it's taken by another user\
-	 * It's a good idea to check this before signing up or changing your email
-	 * @param email Email to check availability of
-	 */
-	public async isEmailAvailable(email: string): Promise<boolean> {
-		const { data } = await this.client.instance.get(Endpoints.emailsAvailable, {
-			params: { email },
-		});
+    /**
+     * Checks if an email is available or if it's taken by another user\
+     * It's a good idea to check this before signing up or changing your email
+     * @param email Email to check availability of
+     */
+    public async isEmailAvailable(email: string): Promise<boolean> {
+        const { data } = await this.client.instance.get(
+            Endpoints.emailsAvailable,
+            {
+                params: { email },
+            },
+        );
 
-		return data.data.available;
-	}
+        return data.data.available;
+    }
 
-	/**
-	 * Fetches a user by their ID or Nick
-	 * @param idOrNick Id or nick of the user
-	 * @param byNick Whether to lookup by nick (Default: false)
-	 * @param cached Whater to return the cached result (Default: true)
-	 * @returns User|null if the client is authorized
-	 * @throws iFunnyError
-	 */
-	public async fetch(
-		idOrNick: string,
-		byNick: boolean = false,
-		cached: boolean = true
-	): Promise<User | null> {
-		try {
-			let user = await this.resolve(idOrNick);
-			if (cached && user) return user;
+    /**
+     * Fetches a user by their ID or Nick
+     * @param idOrNick Id or nick of the user
+     * @param byNick Whether to lookup by nick (Default: false)
+     * @param cached Whater to return the cached result (Default: true)
+     * @returns User|null if the client is authorized
+     * @throws iFunnyError
+     */
+    public async fetch(
+        idOrNick: string,
+        byNick: boolean = false,
+        cached: boolean = true,
+    ): Promise<User | null> {
+        try {
+            let user = await this.resolve(idOrNick);
+            if (cached && user) return user;
 
-			const { data } =
-				await this.client.instance.request<Success<APIUserProfile> | null>({
-					url: Endpoints.user(idOrNick, byNick),
-				});
+            const { data } =
+                await this.client.instance.request<Success<APIUserProfile> | null>(
+                    {
+                        url: Endpoints.user(idOrNick, byNick),
+                    },
+                );
 
-			if (!data) return data;
+            if (!data) return data;
 
-			user = new User(this.client, data.data);
-			this.cache.set(user.id, user);
-			this.cache.set(user.nick, user);
-			return user;
-		} catch (error) {
-			if (error instanceof iFunnyError) {
-				if (error.code === IFUNNY_ERRORS.NOT_FOUND) return null;
-			}
-			throw error;
-		}
-	}
+            user = new User(this.client, data.data);
+            this.cache.set(user.id, user);
+            this.cache.set(user.nick, user);
+            return user;
+        } catch (error) {
+            if (error instanceof iFunnyError) {
+                if (error.code === IFUNNY_ERRORS.NOT_FOUND) return null;
+            }
+            throw error;
+        }
+    }
 }
 
 export default UserManager;

--- a/src/managers/mod.ts
+++ b/src/managers/mod.ts
@@ -1,0 +1,5 @@
+export * from "./FeedManager";
+export * from "./AppManager";
+export * from "./CachedManager";
+export * from "./UserManager";
+export * from "./ContentManager";

--- a/src/structures/Ban.ts
+++ b/src/structures/Ban.ts
@@ -1,8 +1,8 @@
 import {
-	Endpoints,
-	type APIBan,
-	type APIBanReason,
-	type APIBanType,
+    Endpoints,
+    type APIBan,
+    type APIBanReason,
+    type APIBanType,
 } from "@ifunny/ifunny-api-types";
 import { Base } from "./Base";
 import { Comment } from "./Comment";
@@ -14,145 +14,145 @@ import type { User } from "./User";
  * @extends Base<APIBan>
  */
 export class Ban extends Base<APIBan> {
-	/**
-	 * The user attached to the Ban
-	 */
-	readonly #user: User;
+    /**
+     * The user attached to the Ban
+     */
+    readonly #user: User;
 
-	/**
-	 * @param user User the ban is attached to
-	 * @param payload The payload of the Ban
-	 */
-	public constructor(user: User, payload: APIBan) {
-		super(user.client, payload);
-		this.#user = user;
-		this.endpointUrl = Endpoints.bans(user.id, payload.id);
-	}
+    /**
+     * @param user User the ban is attached to
+     * @param payload The payload of the Ban
+     */
+    public constructor(user: User, payload: APIBan) {
+        super(user.client, payload);
+        this.#user = user;
+        this.endpointUrl = Endpoints.bans(user.id, payload.id);
+    }
 
-	/**
-	 * The user attached to the Ban
-	 */
-	public get user(): User {
-		return this.#user;
-	}
+    /**
+     * The user attached to the Ban
+     */
+    public get user(): User {
+        return this.#user;
+    }
 
-	/**
-	 * The type of ban
-	 */
-	public get type(): APIBanType {
-		return this.get("type");
-	}
+    /**
+     * The type of ban
+     */
+    public get type(): APIBanType {
+        return this.get("type");
+    }
 
-	/**
-	 * Timestamp of when the Ban expires
-	 */
-	public get expiresAt(): Date {
-		return new Date(this.get("date_until") * 1000);
-	}
+    /**
+     * Timestamp of when the Ban expires
+     */
+    public get expiresAt(): Date {
+        return new Date(this.get("date_until") * 1000);
+    }
 
-	/**
-	 * How long (in miliseconds) until the Ban expires
-	 */
-	public get expiresIn(): number {
-		return this.expiresAt.getTime() - new Date().getTime();
-	}
+    /**
+     * How long (in miliseconds) until the Ban expires
+     */
+    public get expiresIn(): number {
+        return this.expiresAt.getTime() - new Date().getTime();
+    }
 
-	/**
-	 * The reason for the Ban
-	 */
-	public get reason(): APIBanReason {
-		return this.get("ban_reason");
-	}
+    /**
+     * The reason for the Ban
+     */
+    public get reason(): APIBanReason {
+        return this.get("ban_reason");
+    }
 
-	/**
-	 * The ban reason message
-	 */
-	public get reasonMessage(): string | null {
-		return this.get("ban_reason_message");
-	}
+    /**
+     * The ban reason message
+     */
+    public get reasonMessage(): string | null {
+        return this.get("ban_reason_message");
+    }
 
-	/**
-	 * Can the ban be appealed?
-	 */
-	public get canBeAppealed(): boolean {
-		return this.get("can_be_appealed");
-	}
+    /**
+     * Can the ban be appealed?
+     */
+    public get canBeAppealed(): boolean {
+        return this.get("can_be_appealed");
+    }
 
-	/**
-	 * When the ban was created
-	 */
-	public get createdAt(): Date {
-		return new Date(this.get("created_at") * 1000);
-	}
+    /**
+     * When the ban was created
+     */
+    public get createdAt(): Date {
+        return new Date(this.get("created_at") * 1000);
+    }
 
-	/**
-	 * Not sure what this is
-	 */
-	public get dateUntilMinimum(): number | null {
-		return this.get("date_until_minimum");
-	}
+    /**
+     * Not sure what this is
+     */
+    public get dateUntilMinimum(): number | null {
+        return this.get("date_until_minimum");
+    }
 
-	/**
-	 * Is the Ban active?
-	 */
-	public get isActive(): boolean {
-		return this.get("is_active");
-	}
+    /**
+     * Is the Ban active?
+     */
+    public get isActive(): boolean {
+        return this.get("is_active");
+    }
 
-	/**
-	 * Has the Ban be appealed?
-	 */
-	public get isAppealed(): boolean {
-		return this.get("is_appealed");
-	}
+    /**
+     * Has the Ban be appealed?
+     */
+    public get isAppealed(): boolean {
+        return this.get("is_appealed");
+    }
 
-	/**
-	 * Is the ban shortable?
-	 */
-	public get isShortable(): boolean {
-		return this.get("is_shortable");
-	}
+    /**
+     * Is the ban shortable?
+     */
+    public get isShortable(): boolean {
+        return this.get("is_shortable");
+    }
 
-	/**
-	 * Don't know what this is yet
-	 */
-	public get pid(): number {
-		// TODO: Document what pid is
-		return this.get("pid");
-	}
+    /**
+     * Don't know what this is yet
+     */
+    public get pid(): number {
+        // TODO: Document what pid is
+        return this.get("pid");
+    }
 
-	/**
-	 * The Comment related to the Ban if applicable
-	 */
-	public get relatedComment(): Comment | null {
-		const comment = this.get("related_comment");
-		if (!comment) return null;
-		if (!comment.content) return null;
-		const content = new Content(this.client, comment.content);
-		return new Comment(content, comment);
-	}
+    /**
+     * The Comment related to the Ban if applicable
+     */
+    public get relatedComment(): Comment | null {
+        const comment = this.get("related_comment");
+        if (!comment) return null;
+        if (!comment.content) return null;
+        const content = new Content(this.client, comment.content);
+        return new Comment(content, comment);
+    }
 
-	/**
-	 * The Content related to the Ban if applicable
-	 */
-	public get relatedContent(): Content | null {
-		const content = this.get("related_content");
-		return content ? new Content(this.client, content) : null;
-	}
+    /**
+     * The Content related to the Ban if applicable
+     */
+    public get relatedContent(): Content | null {
+        const content = this.get("related_content");
+        return content ? new Content(this.client, content) : null;
+    }
 
-	/**
-	 * The Ban Type message
-	 */
-	public get typeMessage(): string | null {
-		return this.get("type_message");
-	}
+    /**
+     * The Ban Type message
+     */
+    public get typeMessage(): string | null {
+        return this.get("type_message");
+    }
 
-	/**
-	 * Was the Ban shown to the Client?
-	 */
-	public get wasShown(): boolean {
-		return this.get("was_shown");
-	}
+    /**
+     * Was the Ban shown to the Client?
+     */
+    public get wasShown(): boolean {
+        return this.get("was_shown");
+    }
 }
 
 export default Ban;

--- a/src/structures/BanSmall.ts
+++ b/src/structures/BanSmall.ts
@@ -1,4 +1,8 @@
-import { Endpoints, type APIBanSmall, type APIBanType } from "@ifunny/ifunny-api-types";
+import {
+    Endpoints,
+    type APIBanSmall,
+    type APIBanType,
+} from "@ifunny/ifunny-api-types";
 import { Base } from "./Base";
 import { User } from "./User";
 import type { BaseUser } from "./BaseUser";
@@ -8,50 +12,50 @@ import type { BaseUser } from "./BaseUser";
  * @extends Base<APIBanSmall>
  */
 export class BanSmall extends Base<APIBanSmall> {
-	/**
-	 * User the Ban belongs to
-	 */
-	readonly #user: User;
+    /**
+     * User the Ban belongs to
+     */
+    readonly #user: User;
 
-	/**
-	 * @param client The Client instance
-	 * @param user User or Id of the user that the ban belongs to
-	 * @param payload Payload of the ban if applicable
-	 */
-	public constructor(user: User | BaseUser, payload: APIBanSmall) {
-		super(user.client, payload);
-		this.#user = user instanceof User ? user : new User(user.client, user.payload);
-		this.payload = payload;
-		this.endpointUrl = Endpoints.bans(this.#user.id, this.id);
-	}
+    /**
+     * @param user User or Id of the user that the ban belongs to
+     * @param payload Payload of the ban if applicable
+     */
+    public constructor(user: User | BaseUser, payload: APIBanSmall) {
+        super(user.client, payload);
+        this.#user =
+            user instanceof User ? user : new User(user.client, user.payload);
+        this.payload = payload;
+        this.endpointUrl = Endpoints.bans(this.#user.id, this.id);
+    }
 
-	/**
-	 * Date object of when the ban expires
-	 */
-	public get expiresAt(): Date {
-		return new Date(this.get("date_until") * 1000);
-	}
+    /**
+     * Date object of when the ban expires
+     */
+    public get expiresAt(): Date {
+        return new Date(this.get("date_until") * 1000);
+    }
 
-	/**
-	 * How long until the ban expires in milliseconds
-	 */
-	public get expiresIn(): number {
-		return this.expiresAt.getTime() - new Date().getTime();
-	}
+    /**
+     * How long until the ban expires in milliseconds
+     */
+    public get expiresIn(): number {
+        return this.expiresAt.getTime() - new Date().getTime();
+    }
 
-	/**
-	 * The type of the ban
-	 */
-	public get type(): APIBanType {
-		return this.get("type");
-	}
+    /**
+     * The type of the ban
+     */
+    public get type(): APIBanType {
+        return this.get("type");
+    }
 
-	/**
-	 * User that the ban belongs to
-	 */
-	public get user(): User {
-		return this.#user;
-	}
+    /**
+     * User that the ban belongs to
+     */
+    public get user(): User {
+        return this.#user;
+    }
 }
 
 export default BanSmall;

--- a/src/structures/Base.ts
+++ b/src/structures/Base.ts
@@ -7,116 +7,117 @@ import type { Nullify } from "../utils/Types";
  * @template Payload The payload of the object
  */
 export class Base<Payload extends APIBasePayload> {
-	/**
-	 * Client instance attached to the Object
-	 */
-	readonly #client: Client;
+    /**
+     * Client instance attached to the Object
+     */
+    readonly #client: Client;
 
-	/**
-	 * The payload of the object.
-	 */
-	#payload: Payload;
+    /**
+     * The payload of the object.
+     */
+    #payload: Payload;
 
-	/**
-	 * Endpoint url the object will request to
-	 */
-	#endpointUrl: string = Endpoints.account;
+    /**
+     * Endpoint url the object will request to
+     */
+    #endpointUrl: string = Endpoints.account;
 
-	/**
-	 * @param client The client instance
-	 * @param payload The payload of the object
-	 */
-	public constructor(client: Client, payload: Payload) {
-		this.#client = client;
-		this.#payload = payload;
-	}
+    /**
+     * @param client The client instance
+     * @param payload The payload of the object
+     */
+    public constructor(client: Client, payload: Payload) {
+        this.#client = client;
+        this.#payload = payload;
+    }
 
-	/**
-	 * The client instance attached to the Object
-	 */
-	public get client() {
-		return this.#client;
-	}
+    /**
+     * The client instance attached to the Object
+     */
+    public get client() {
+        return this.#client;
+    }
 
-	/**
-	 * Get the payload of the object
-	 */
-	public get payload(): Payload {
-		return this.#payload;
-	}
+    /**
+     * Get the payload of the object
+     */
+    public get payload(): Payload {
+        return this.#payload;
+    }
 
-	/**
-	 * Updates the payload of the object.
-	 * @param payload The payload to merge into the current instance
-	 * @returns The current instance
-	 */
-	public set payload(payload: Partial<Payload>) {
-		Object.assign(this.#payload, payload);
-	}
+    /**
+     * Updates the payload of the object.
+     * @param payload The payload to merge into the current instance
+     * @returns The current instance
+     */
+    public set payload(payload: Partial<Payload>) {
+        Object.assign(this.#payload, payload);
+    }
 
-	/**
-	 * Endpoint url for requests to update the payload
-	 */
-	protected get endpointUrl(): string {
-		return this.#endpointUrl;
-	}
+    /**
+     * Endpoint url for requests to update the payload
+     */
+    protected get endpointUrl(): string {
+        return this.#endpointUrl;
+    }
 
-	protected set endpointUrl(value: string) {
-		this.#endpointUrl = `${value}`;
-	}
+    protected set endpointUrl(value: string) {
+        this.#endpointUrl = `${value}`;
+    }
 
-	/**
-	 * Fetches the objects data from it's endpoint
-	 * @returns The instance of the object
-	 */
-	public async fetch(): Promise<this> {
-		const response = await this.client.instance.get(this.endpointUrl);
-		return (this.payload = response.data.data);
-	}
+    /**
+     * Fetches the objects data from it's endpoint
+     * @returns The instance of the object
+     */
+    public async fetch(): Promise<this> {
+        const response = await this.client.instance.get(this.endpointUrl);
+        return (this.payload = response.data.data);
+    }
 
-	/**
-	 * Gets the value from the payload from its key
-	 * @param key The key to get the value of
-	 * @returns
-	 */
-	protected get<P extends Payload, K extends keyof P>(key: K): Nullify<P[K]> {
-		// @ts-ignore
-		return (this.payload[key] ?? null) as Nullify<P[K]>;
-	}
+    /**
+     * Gets the value from the payload from its key
+     * @param key The key to get the value of
+     * @returns
+     */
+    protected get<P extends Payload, K extends keyof Payload>(
+        key: K,
+    ): Nullify<Payload[K]> {
+        return (this.payload[key] ?? null) as Nullify<P[K]>;
+    }
 
-	/**
-	 * The unique id of the object
-	 */
-	public get id(): string {
-		return this.get("id");
-	}
+    /**
+     * The unique id of the object
+     */
+    public get id(): string {
+        return this.get("id");
+    }
 
-	/**
-	 * Creates a new instance of the same structure with the same payload.
-	 * @returns A clone of the current instance
-	 */
-	protected _clone(): this {
-		return Object.assign(Object.create(this), this);
-	}
+    /**
+     * Creates a new instance of the same structure with the same payload.
+     * @returns A clone of the current instance
+     */
+    protected _clone(): this {
+        return Object.assign(Object.create(this), this);
+    }
 
-	/**
-	 * @returns The object's id
-	 */
-	public valueOf(): string {
-		return this.id;
-	}
+    /**
+     * @returns The object's id
+     */
+    public valueOf(): string {
+        return this.id;
+    }
 
-	/**
-	 * Converts the object instance into JSON
-	 * @returns Stringified payload of the object
-	 */
-	public toJSON(): string {
-		return JSON.stringify(this.payload, null, 2);
-	}
+    /**
+     * Converts the object instance into JSON
+     * @returns Stringified payload of the object
+     */
+    public toJSON(): string {
+        return JSON.stringify(this.payload, null, 2);
+    }
 
-	public toString(): string {
-		return `${this.constructor.name} - ${this.id}`;
-	}
+    public toString(): string {
+        return `${this.constructor.name} - ${this.id}`;
+    }
 }
 
 export default Base;

--- a/src/structures/BaseComment.ts
+++ b/src/structures/BaseComment.ts
@@ -1,8 +1,8 @@
 import {
-	Endpoints,
-	type APIComment,
-	type APICommentNum,
-	type APICommentState,
+    Endpoints,
+    type APIComment,
+    type APICommentNum,
+    type APICommentState,
 } from "@ifunny/ifunny-api-types";
 import { Base } from "./Base";
 import { Comment } from "./Comment";
@@ -15,142 +15,144 @@ import type { Content } from "./Content";
  * @extends Base<APIComment>
  */
 export class BaseComment extends Base<APIComment> {
-	/**
-	 * The author of the comment
-	 */
-	#author: SimpleUser | null = null;
-	/**
-	 * The content of the comment
-	 */
-	#content: Content;
+    /**
+     * The author of the comment
+     */
+    #author: SimpleUser | null = null;
+    /**
+     * The content of the comment
+     */
+    #content: Content;
 
-	/**
-	 * @param content Content the Comment is attached to
-	 * @param payload Payload of the Comment
-	 */
-	public constructor(content: Content, payload: APIComment) {
-		super(content.client, payload);
-		this.#content = content;
-		this.endpointUrl = Endpoints.comments(this.content.id, this.payload.id);
-	}
+    /**
+     * @param content Content the Comment is attached to
+     * @param payload Payload of the Comment
+     */
+    public constructor(content: Content, payload: APIComment) {
+        super(content.client, payload);
+        this.#content = content;
+        this.endpointUrl = Endpoints.comments(this.content.id, this.payload.id);
+    }
 
-	/**
-	 * Content ID the comment is attached to
-	 */
-	public get contentId(): string {
-		return this.get("cid");
-	}
+    /**
+     * Content ID the comment is attached to
+     */
+    public get contentId(): string {
+        return this.get("cid");
+    }
 
-	/**
-	 * Content attached to the Comment
-	 */
-	public get content(): Content {
-		return this.#content;
-	}
+    /**
+     * Content attached to the Comment
+     */
+    public get content(): Content {
+        return this.#content;
+    }
 
-	/**
-	 * Thumbnails for the content
-	 */
-	public get thumbnails(): Thumbnail | null {
-		const thumbs = this.get("content_thumbs");
-		return thumbs ? new Thumbnail(thumbs) : null;
-	}
+    /**
+     * Thumbnails for the content
+     */
+    public get thumbnails(): Thumbnail | null {
+        const thumbs = this.get("content_thumbs");
+        return thumbs ? new Thumbnail(thumbs) : null;
+    }
 
-	/**
-	 * Returns the date when the comment was created.
-	 * @returns The comment's date as a `Date` object.
-	 */
+    /**
+     * Returns the date when the comment was created.
+     * @returns The comment's date as a `Date` object.
+     */
 
-	public get date(): Date {
-		return new Date(this.get("date") * 1000);
-	}
+    public get date(): Date {
+        return new Date(this.get("date") * 1000);
+    }
 
-	/**
-	 * Whether the comment has been edited.
-	 * @returns True if the comment has been edited, false otherwise.
-	 */
-	public get isEdited(): boolean {
-		return this.get("is_edited");
-	}
+    /**
+     * Whether the comment has been edited.
+     * @returns True if the comment has been edited, false otherwise.
+     */
+    public get isEdited(): boolean {
+        return this.get("is_edited");
+    }
 
-	/**
-	 * Whether the comment is a reply to another comment.
-	 * @returns True if the comment is a reply, false otherwise.
-	 */
-	public get isReply(): boolean {
-		return this.get("is_reply");
-	}
+    /**
+     * Whether the comment is a reply to another comment.
+     * @returns True if the comment is a reply, false otherwise.
+     */
+    public get isReply(): boolean {
+        return this.get("is_reply");
+    }
 
-	/**
-	 * Whether the comment has been smiled by the user.
-	 * @returns True if the comment has been smiled, false otherwise.
-	 */
-	public get isSmiled(): boolean {
-		return this.get("is_smiled");
-	}
+    /**
+     * Whether the comment has been smiled by the user.
+     * @returns True if the comment has been smiled, false otherwise.
+     */
+    public get isSmiled(): boolean {
+        return this.get("is_smiled");
+    }
 
-	/**
-	 * Whether the user has un-smiled the comment.
-	 * @returns True if the comment has been un-smiled, false otherwise.
-	 */
-	public get isUnsmiled(): boolean {
-		return this.get("is_unsmiled");
-	}
+    /**
+     * Whether the user has un-smiled the comment.
+     * @returns True if the comment has been un-smiled, false otherwise.
+     */
+    public get isUnsmiled(): boolean {
+        return this.get("is_unsmiled");
+    }
 
-	/**
-	 * The last reply to the comment.
-	 * @returns The last reply to the comment, or null if there are no replies.
-	 */
-	public get lastReply(): Comment | null {
-		const reply = this.get("last_reply");
-		return reply ? new Comment(this.content, reply) : null;
-	}
+    /**
+     * The last reply to the comment.
+     * @returns The last reply to the comment, or null if there are no replies.
+     */
+    public get lastReply(): Comment | null {
+        const reply = this.get("last_reply");
+        return reply ? new Comment(this.content, reply) : null;
+    }
 
-	/**
-	 * The number of the comment.
-	 * @returns The number of the comment.
-	 */
-	public get num(): APICommentNum {
-		return this.get("num");
-	}
+    /**
+     * The number of the comment.
+     * @returns The number of the comment.
+     */
+    public get num(): APICommentNum {
+        return this.get("num");
+    }
 
-	/**
-	 * The state of the comment.
-	 * @returns The state of the comment, or null if the state is not available.
-	 */
-	public get state(): APICommentState | null {
-		return this.get("state");
-	}
+    /**
+     * The state of the comment.
+     * @returns The state of the comment, or null if the state is not available.
+     */
+    public get state(): APICommentState | null {
+        return this.get("state");
+    }
 
-	/**
-	 * The text of the Comment. Can be an empty string
-	 */
-	public get text(): string {
-		return this.get("text");
-	}
+    /**
+     * The text of the Comment. Can be an empty string
+     */
+    public get text(): string {
+        return this.get("text");
+    }
 
-	/**
-	 * Author of the Comment
-	 * @alias creator
-	 * @example
-	 * const author = comment.author; // SimpleUser
-	 * const user = await author.user(); // Full User
-	 */
-	public get author(): SimpleUser | null {
-		const user = this.get("user");
-		return (this.#author ??= user ? new SimpleUser(this.client, user) : null);
-	}
+    /**
+     * Author of the Comment
+     * Alias for {@link creator}
+     * @example
+     * const author = comment.author; // SimpleUser
+     * const user = await author.user(); // Full User
+     */
+    public get author(): SimpleUser | null {
+        const user = this.get("user");
+        return (this.#author ??= user
+            ? new SimpleUser(this.client, user)
+            : null);
+    }
 
-	/**
-	 * Author of the Comment
-	 * @alias author
-	 * @example
-	 * const author = comment.author; // SimpleUser
-	 * const user = await author.user(); // Full User
-	 */
-	public get creator(): SimpleUser | null {
-		return this.author;
-	}
+    /**
+     * Author of the Comment
+     * Alias for {@link author}
+     * @example
+     * const author = comment.author; // SimpleUser
+     * const user = await author.user(); // Full User
+     */
+    public get creator(): SimpleUser | null {
+        return this.author;
+    }
 }
 
 export default BaseComment;

--- a/src/structures/BaseContent.ts
+++ b/src/structures/BaseContent.ts
@@ -1,18 +1,18 @@
 import {
-	ContentType,
-	Endpoints,
-	type APIContent,
-	type APIContentCopyright,
-	type APIContentData,
-	type APIContentNums,
-	type APIContentShotStatus,
-	type APIContentSource,
-	type APIContentState,
-	type APIContentThumbnail,
-	type APIContentType,
-	type APIContentVisibility,
-	type APIFeedFrom,
-	type Size,
+    ContentType,
+    Endpoints,
+    type APIContent,
+    type APIContentCopyright,
+    type APIContentData,
+    type APIContentNums,
+    type APIContentShotStatus,
+    type APIContentSource,
+    type APIContentState,
+    type APIContentThumbnail,
+    type APIContentType,
+    type APIContentVisibility,
+    type APIFeedFrom,
+    type Size,
 } from "@ifunny/ifunny-api-types";
 import { Base } from "./Base";
 import { Creator } from "./Creator";
@@ -23,322 +23,322 @@ import type { Client } from "../client/Client";
  * @extends Base<APIContent>
  */
 export class BaseContent extends Base<APIContent> {
-	#creator: Creator | null = null;
+    #creator: Creator | null = null;
 
-	/**
-	 * @param client Client instance associated with the Content
-	 * @param payload Payload of the Content
-	 */
-	public constructor(client: Client, payload: APIContent) {
-		super(client, payload);
-		this.endpointUrl = Endpoints.content(payload.id);
-		this.payload = payload;
-	}
+    /**
+     * @param client Client instance associated with the Content
+     * @param payload Payload of the Content
+     */
+    public constructor(client: Client, payload: APIContent) {
+        super(client, payload);
+        this.endpointUrl = Endpoints.content(payload.id);
+        this.payload = payload;
+    }
 
-	/**
-	 * This data is typically retrieved by using the content's type as a key for the content.
-	 * @example
-	 * content.payload[content.type] // Key isn't always the type
-	 */
-	public get data(): APIContentData | null {
-		switch (this.payload.type) {
-			case ContentType.VIDEO_CLIP:
-				return this.payload.video_clip ?? null;
-			case ContentType.VIDEO:
-				return this.payload.video ?? null;
-			case ContentType.VINE:
-				return this.payload.vine ?? null;
-			case ContentType.COUB:
-				return this.payload.coub ?? null;
-			case ContentType.GIF:
-			case ContentType.GIF_CAPTION:
-				return this.payload.gif ?? null;
-			case ContentType.CAPTION:
-				return this.payload.caption ?? null;
-			case ContentType.PIC:
-				return this.payload.pic ?? null;
-			case ContentType.MEME:
-				return this.payload.mem ?? null;
-			case ContentType.COMICS:
-				return this.payload.comics ?? null;
-			case ContentType.APP:
-				return this.payload.app ?? null;
-			case ContentType.OLD:
-			case ContentType.DEM:
-			default:
-				// @ts-ignore
-				return this.payload[this.payload.type] ?? null; // ? Currently undocumented datas
-		}
-	}
+    /**
+     * This data is typically retrieved by using the content's type as a key for the content.
+     * @example
+     * content.payload[content.type] // Key isn't always the type
+     */
+    public get data(): APIContentData | null {
+        switch (this.payload.type) {
+            case ContentType.VIDEO_CLIP:
+                return this.payload.video_clip ?? null;
+            case ContentType.VIDEO:
+                return this.payload.video ?? null;
+            case ContentType.VINE:
+                return this.payload.vine ?? null;
+            case ContentType.COUB:
+                return this.payload.coub ?? null;
+            case ContentType.GIF:
+            case ContentType.GIF_CAPTION:
+                return this.payload.gif ?? null;
+            case ContentType.CAPTION:
+                return this.payload.caption ?? null;
+            case ContentType.PIC:
+                return this.payload.pic ?? null;
+            case ContentType.MEME:
+                return this.payload.mem ?? null;
+            case ContentType.COMICS:
+                return this.payload.comics ?? null;
+            case ContentType.APP:
+                return this.payload.app ?? null;
+            case ContentType.OLD:
+            case ContentType.DEM:
+            default:
+                // @ts-ignore
+                return this.payload[this.payload.type] ?? null; // ? Currently undocumented datas
+        }
+    }
 
-	/**
-	 * The creator of the post
-	 * @alias creator
-	 */
-	get author(): Creator | null {
-		return this.creator;
-	}
+    /**
+     * The creator of the post
+     * Alias for {@link creator}
+     */
+    get author(): Creator | null {
+        return this.creator;
+    }
 
-	/**
-	 * Content background color
-	 */
-	public get bgColor(): string | null {
-		return this.get("bg_color");
-	}
+    /**
+     * Content background color
+     */
+    public get bgColor(): string | null {
+        return this.get("bg_color");
+    }
 
-	/**
-	 * Can the post be boosted?
-	 */
-	public get canBeBoosted(): boolean {
-		return this.get("can_be_boosted");
-	}
+    /**
+     * Can the post be boosted?
+     */
+    public get canBeBoosted(): boolean {
+        return this.get("can_be_boosted");
+    }
 
-	/**
-	 * Content url that can be opened in app
-	 */
-	public get canonicalUrl(): string {
-		return this.get("canonical_url");
-	}
+    /**
+     * Content url that can be opened in app
+     */
+    public get canonicalUrl(): string {
+        return this.get("canonical_url");
+    }
 
-	/**
-	 * Copywright information attached to the content
-	 */
-	public get copyright(): APIContentCopyright {
-		return this.get("copyright") ?? {};
-	}
+    /**
+     * Copywright information attached to the content
+     */
+    public get copyright(): APIContentCopyright {
+        return this.get("copyright") ?? {};
+    }
 
-	/**
-	 * The creator of the post
-	 * @alias author
-	 */
-	public get creator(): Creator | null {
-		if (this.#creator) return this.#creator;
-		const user = this.get("creator");
-		return user ? (this.#creator ??= new Creator(this.client, user)) : user;
-	}
+    /**
+     * The creator of the post
+     * Alias for {@link author}
+     */
+    public get creator(): Creator | null {
+        if (this.#creator) return this.#creator;
+        const user = this.get("creator");
+        return user ? (this.#creator ??= new Creator(this.client, user)) : user;
+    }
 
-	/**
-	 * When the content was created
-	 */
-	public get createdAt(): Date {
-		return new Date(this.get("date_create") * 1000);
-	}
+    /**
+     * When the content was created
+     */
+    public get createdAt(): Date {
+        return new Date(this.get("date_create") * 1000);
+    }
 
-	/**
-	 * Not sure what this is
-	 */
-	public get fastStart(): boolean {
-		return this.get("fast_start");
-	}
+    /**
+     * Not sure what this is
+     */
+    public get fastStart(): boolean {
+        return this.get("fast_start");
+    }
 
-	/**
-	 * Title set by iFunny
-	 */
-	public get fixedTitle(): string | null {
-		return this.get("fixed_title");
-	}
+    /**
+     * Title set by iFunny
+     */
+    public get fixedTitle(): string | null {
+        return this.get("fixed_title");
+    }
 
-	/**
-	 * The ID of the Content.
-	 */
-	public override get id(): string {
-		return super.id;
-	}
+    /**
+     * The ID of the Content.
+     */
+    public override get id(): string {
+        return super.id;
+    }
 
-	/**
-	 * Was the post removed by iFunny?
-	 */
-	public get isAbused(): boolean {
-		return this.get("is_abused");
-	}
+    /**
+     * Was the post removed by iFunny?
+     */
+    public get isAbused(): boolean {
+        return this.get("is_abused");
+    }
 
-	/**
-	 * Was the post featured?
-	 */
-	public get isFeatured(): boolean {
-		return this.get("is_featured");
-	}
+    /**
+     * Was the post featured?
+     */
+    public get isFeatured(): boolean {
+        return this.get("is_featured");
+    }
 
-	/**
-	 * Is the Content pinned by the author?
-	 */
-	public get isPinned(): boolean {
-		return this.get("is_pinned");
-	}
+    /**
+     * Is the Content pinned by the author?
+     */
+    public get isPinned(): boolean {
+        return this.get("is_pinned");
+    }
 
-	/**
-	 * Is the Content republished by the Client?
-	 */
-	public get isRepublished(): boolean {
-		return this.get("is_republished");
-	}
+    /**
+     * Is the Content republished by the Client?
+     */
+    public get isRepublished(): boolean {
+        return this.get("is_republished");
+    }
 
-	/**
-	 * Is the Content smiled by the Client?
-	 */
-	public get isSmiled(): boolean {
-		return this.get("is_smiled");
-	}
+    /**
+     * Is the Content smiled by the Client?
+     */
+    public get isSmiled(): boolean {
+        return this.get("is_smiled");
+    }
 
-	/**
-	 * When the Content was featured if it was featured
-	 */
-	public get featuredAt(): Date | null {
-		const ms = this.get("issue_at");
-		return ms ? new Date(ms * 1000) : null;
-	}
+    /**
+     * When the Content was featured if it was featured
+     */
+    public get featuredAt(): Date | null {
+        const ms = this.get("issue_at");
+        return ms ? new Date(ms * 1000) : null;
+    }
 
-	/**
-	 * The tag to use for the 'from' parameter
-	 */
-	public get ftag(): APIFeedFrom | null {
-		return this.get("ftag");
-	}
+    /**
+     * The tag to use for the 'from' parameter
+     */
+    public get ftag(): APIFeedFrom | null {
+        return this.get("ftag");
+    }
 
-	/**
-	 * The link of the content that can be opened in iFunny
-	 */
-	public get link(): string {
-		return this.get("link");
-	}
+    /**
+     * The link of the content that can be opened in iFunny
+     */
+    public get link(): string {
+        return this.get("link");
+    }
 
-	/**
-	 * The numbers attached to the Content
-	 * @alias stats
-	 */
-	public get num(): APIContentNums {
-		return this.get("num");
-	}
+    /**
+     * The numbers attached to the Content
+     * Alias for {@link stats}
+     */
+    public get num(): APIContentNums {
+        return this.get("num");
+    }
 
-	/**
-	 * Text generated from iFunny's OCR (Optical Character Recognition)
-	 */
-	public get ocrText(): string | null {
-		return this.get("ocr_text");
-	}
+    /**
+     * Text generated from iFunny's OCR (Optical Character Recognition)
+     */
+    public get ocrText(): string | null {
+        return this.get("ocr_text");
+    }
 
-	/**
-	 * Does the Content use the Old Watermark
-	 */
-	public get oldWatermark(): boolean {
-		return this.get("old_watermark");
-	}
+    /**
+     * Does the Content use the Old Watermark
+     */
+    public get oldWatermark(): boolean {
+        return this.get("old_watermark");
+    }
 
-	/**
-	 * When the Content was published or will publish
-	 */
-	public get publishedAt(): Date {
-		const seconds = this.get("publish_at") * 1000;
-		return new Date(seconds);
-	}
+    /**
+     * When the Content was published or will publish
+     */
+    public get publishedAt(): Date {
+        const seconds = this.get("publish_at") * 1000;
+        return new Date(seconds);
+    }
 
-	/**
-	 * The risk level of the Content\
-	 * Default: `1`
-	 */
-	public get risk(): number {
-		return this.get("risk");
-	}
+    /**
+     * The risk level of the Content\
+     * Default: `1`
+     */
+    public get risk(): number {
+        return this.get("risk");
+    }
 
-	/**
-	 * The shot status of the content\
-	 * `approved` - Content can be posted in comments\
-	 * `shot` - Content can't be posted in comments\
-	 * `hardShot` - Content was removed by iFunny and is not viewable
-	 */
-	public get shotStatus(): APIContentShotStatus {
-		return this.get("shot_status");
-	}
+    /**
+     * The shot status of the content\
+     * `approved` - Content can be posted in comments\
+     * `shot` - Content can't be posted in comments\
+     * `hardShot` - Content was removed by iFunny and is not viewable
+     */
+    public get shotStatus(): APIContentShotStatus {
+        return this.get("shot_status");
+    }
 
-	/**
-	 * The size of the Content
-	 */
-	public get size(): Size {
-		return this.get("size");
-	}
+    /**
+     * The size of the Content
+     */
+    public get size(): Size {
+        return this.get("size");
+    }
 
-	/**
-	 * The source of the content if it exists
-	 */
-	public get source(): APIContentSource | null {
-		return this.get("source");
-	}
+    /**
+     * The source of the content if it exists
+     */
+    public get source(): APIContentSource | null {
+        return this.get("source");
+    }
 
-	/**
-	 * The state of the Content
-	 */
-	public get state(): APIContentState {
-		return this.get("state");
-	}
+    /**
+     * The state of the Content
+     */
+    public get state(): APIContentState {
+        return this.get("state");
+    }
 
-	/**
-	 * The numbers attached to the Content
-	 * @alias num
-	 */
-	public get stats(): APIContentNums {
-		return this.num;
-	}
+    /**
+     * The numbers attached to the Content
+     * Alias for {@link num}
+     */
+    public get stats(): APIContentNums {
+        return this.num;
+    }
 
-	/**
-	 * All tags on the Content
-	 */
-	public get tags(): string[] {
-		return this.get("tags");
-	}
+    /**
+     * All tags on the Content
+     */
+    public get tags(): string[] {
+        return this.get("tags");
+    }
 
-	/**
-	 * Thumbnail of the Content
-	 */
-	public get thumbnail(): APIContentThumbnail {
-		return this.get("thumb");
-	}
+    /**
+     * Thumbnail of the Content
+     */
+    public get thumbnail(): APIContentThumbnail {
+        return this.get("thumb");
+    }
 
-	/**
-	 * The Title of the content
-	 */
-	public get title(): string {
-		return this.get("title");
-	}
+    /**
+     * The Title of the content
+     */
+    public get title(): string {
+        return this.get("title");
+    }
 
-	/**
-	 * URL of the original source if it exists
-	 */
-	public get tracebackUrl(): string | null {
-		return this.get("traceback_url");
-	}
+    /**
+     * URL of the original source if it exists
+     */
+    public get tracebackUrl(): string | null {
+        return this.get("traceback_url");
+    }
 
-	/**
-	 * The type of the post
-	 */
-	public get type(): APIContentType {
-		return this.get("type");
-	}
+    /**
+     * The type of the post
+     */
+    public get type(): APIContentType {
+        return this.get("type");
+    }
 
-	/**
-	 * URL of the Content
-	 */
-	public get url(): string {
-		return this.get("url");
-	}
+    /**
+     * URL of the Content
+     */
+    public get url(): string {
+        return this.get("url");
+    }
 
-	/**
-	 * The Content's visibility status\
-	 * `public` - Content shows up in collective and explore
-	 * `subscribers` - Content is hidden from Collective and Explore
-	 * `closed` - Content is not visible by anyone but the author
-	 */
-	public get visibility(): APIContentVisibility {
-		return this.get("visibility");
-	}
+    /**
+     * The Content's visibility status\
+     * `public` - Content shows up in collective and explore
+     * `subscribers` - Content is hidden from Collective and Explore
+     * `closed` - Content is not visible by anyone but the author
+     */
+    public get visibility(): APIContentVisibility {
+        return this.get("visibility");
+    }
 
-	/**
-	 * When concatenated with a string, this automatically returns the content's id instead of the Content object.
-	 * @example
-	 * console.log(`Found post: ${content}`); //  Logs: Found post: 2hu2ab8J
-	 */
-	public override toString(): string {
-		return this.id;
-	}
+    /**
+     * When concatenated with a string, this automatically returns the content's id instead of the Content object.
+     * @example
+     * console.log(`Found post: ${content}`); //  Logs: Found post: 2hu2ab8J
+     */
+    public override toString(): string {
+        return this.id;
+    }
 }
 
 export default BaseContent;

--- a/src/structures/BaseFeed.ts
+++ b/src/structures/BaseFeed.ts
@@ -4,90 +4,90 @@ import type { Client } from "../client/Client";
  * The type of iFunny feed.
  */
 export enum FeedType {
-	/**
-	 * The featured feed, which contains popular and trending content.
-	 */
-	FEATURES = "feeds/featured",
-	/**
-	 * The collective feed, which contains all content uploaded to iFunny.
-	 */
-	COLLECTIVE = "feeds/collective",
-	/**
-	 * The home feed, which contains content from the user's subscriptions and recommendations.
-	 */
-	HOME = "timelines/home",
-	/**
-	 * A user's personal timeline feed, which contains their own content.
-	 */
-	TIMELINE = "timelines/users",
+    /**
+     * The featured feed, which contains popular and trending content.
+     */
+    FEATURES = "feeds/featured",
+    /**
+     * The collective feed, which contains all content uploaded to iFunny.
+     */
+    COLLECTIVE = "feeds/collective",
+    /**
+     * The home feed, which contains content from the user's subscriptions and recommendations.
+     */
+    HOME = "timelines/home",
+    /**
+     * A user's personal timeline feed, which contains their own content.
+     */
+    TIMELINE = "timelines/users",
 }
 
 /**
  * Configuration options for paginating iFunny API responses.
  */
 export interface PaginateConfig {
-	/**
-	 * The maximum number of items to include in the response.
-	 * If not specified, the default limit will be used.
-	 */
-	limit?: number;
-	/**
-	 * Is the Client a new user?
-	 * ? Seems to only be for server side use.
-	 */
-	is_new?: boolean;
-	/**
-	 * A URL-encoded string representing the cursor for the next page of results.
-	 * This should be set to the value of the `next` property from the previous response.
-	 */
-	next?: string;
-	/**
-	 * A URL-encoded string representing the cursor for the previous page of results.
-	 * This should be set to the value of the `prev` property from the previous response.
-	 */
-	prev?: string;
+    /**
+     * The maximum number of items to include in the response.
+     * If not specified, the default limit will be used.
+     */
+    limit?: number;
+    /**
+     * Is the Client a new user?
+     * ? Seems to only be for server side use.
+     */
+    is_new?: boolean;
+    /**
+     * A URL-encoded string representing the cursor for the next page of results.
+     * This should be set to the value of the `next` property from the previous response.
+     */
+    next?: string;
+    /**
+     * A URL-encoded string representing the cursor for the previous page of results.
+     * This should be set to the value of the `prev` property from the previous response.
+     */
+    prev?: string;
 }
 
 /**
  * Base Feed class
  */
 export class BaseFeed {
-	/**
-	 * The Client instance
-	 */
-	readonly #client: Client;
-	/**
-	 * Url for the feed
-	 */
-	readonly #url: string;
+    /**
+     * The Client instance
+     */
+    readonly #client: Client;
+    /**
+     * Url for the feed
+     */
+    readonly #url: string;
 
-	/**
-	 * Types of feed
-	 */
-	public static readonly Types = FeedType;
+    /**
+     * Types of feed
+     */
+    public static readonly Types = FeedType;
 
-	/**
-	 * @param client Client attached to the BaseFeed
-	 * @param url The url for the feed
-	 */
-	public constructor(client: Client, url: string) {
-		this.#client = client;
-		this.#url = url;
-	}
+    /**
+     * @param client Client attached to the BaseFeed
+     * @param url The url for the feed
+     */
+    public constructor(client: Client, url: string) {
+        this.#client = client;
+        this.#url = url;
+    }
 
-	/**
-	 * Client attached to the Feed
-	 */
-	public get client(): Client {
-		return this.#client;
-	}
+    /**
+     * Client attached to the Feed
+     */
+    public get client(): Client {
+        return this.#client;
+    }
 
-	/**
-	 * Url used for pagination
-	 */
-	public get url(): string {
-		return this.#url;
-	}
+    /**
+     * Url used for pagination
+     */
+    public get url(): string {
+        return this.#url;
+    }
 }
 
 export default BaseFeed;

--- a/src/structures/BaseUser.ts
+++ b/src/structures/BaseUser.ts
@@ -1,12 +1,12 @@
 import {
-	Endpoints,
-	type APINickColor,
-	type APIProfilePhoto,
-	type APIUserAllSocials,
-	type APIUserBlockType,
-	type APIUserMessagePrivacy,
-	type APIUserProfile,
-	type APIUserProfileNums,
+    Endpoints,
+    type APINickColor,
+    type APIProfilePhoto,
+    type APIUserAllSocials,
+    type APIUserBlockType,
+    type APIUserMessagePrivacy,
+    type APIUserProfile,
+    type APIUserProfileNums,
 } from "@ifunny/ifunny-api-types";
 import { BanSmall } from "./BanSmall";
 import { Base } from "./Base";
@@ -18,296 +18,304 @@ import type { Client } from "../client/Client";
  * @extends Base<APIUserProfile>
  */
 export class BaseUser extends Base<APIUserProfile> {
-	/**
-	 * @param client The client instance
-	 * @param payload Payload to create the User with
-	 */
-	public constructor(client: Client, payload: APIUserProfile) {
-		super(client, payload);
-		this.payload = payload;
-		this.endpointUrl = Endpoints.user(payload.id);
-	}
+    /**
+     * @param client The client instance
+     * @param payload Payload to create the User with
+     */
+    public constructor(client: Client, payload: APIUserProfile) {
+        super(client, payload);
+        this.payload = payload;
+        this.endpointUrl = Endpoints.user(payload.id);
+    }
 
-	/**
-	 * The user's about text
-	 * @alias bio
-	 */
-	public get about(): string {
-		return this.get("about");
-	}
+    /**
+     * The user's about text
+     * Alias for {@link bio}
+     */
+    public get about(): string {
+        return this.get("about");
+    }
 
-	/**
-	 * Does the user have you blocked?
-	 */
-	public get areYouBlocked(): boolean {
-		return this.get("are_you_blocked");
-	}
+    /**
+     * Does the user have you blocked?
+     */
+    public get areYouBlocked(): boolean {
+        return this.get("are_you_blocked");
+    }
 
-	/**
-	 * Collection of Bans the user has
-	 */
-	public get bans(): BanSmall[] {
-		const bans = this.get("bans") ?? [];
-		return bans.map((ban) => new BanSmall(this, ban));
-	}
+    /**
+     * Collection of Bans the user has
+     */
+    public get bans(): BanSmall[] {
+        const bans = this.get("bans") ?? [];
+        return bans.map((ban) => new BanSmall(this, ban));
+    }
 
-	/**
-	 * The user's about text
-	 * @alias about
-	 */
-	public get bio(): string {
-		return this.about;
-	}
+    /**
+     * The user's about text
+     * Alias for {@link about}
+     */
+    public get bio(): string {
+        return this.about;
+    }
 
-	/**
-	 * The block type if the user is blocked
-	 */
-	public get blockType(): APIUserBlockType | null {
-		return this.get("block_type");
-	}
+    /**
+     * The block type if the user is blocked
+     */
+    public get blockType(): APIUserBlockType | null {
+        return this.get("block_type");
+    }
 
-	/**
-	 * Can the Client chat with the user?\
-	 * ? Not checked by the backend
-	 * @alias is_available_for_chat
-	 */
-	public get canChat(): boolean {
-		return this.isAvailableForChat;
-	}
+    /**
+     * Can the Client chat with the user?\
+     * ? Not checked by the backend
+     * Alias for {@link isAvailableForChat}
+     */
+    public get canChat(): boolean {
+        return this.isAvailableForChat;
+    }
 
-	/**
-	 * The user's chat privacy
-	 */
-	public get chatPrivacy(): APIUserMessagePrivacy {
-		return this.get("messaging_privacy_status");
-	}
+    /**
+     * The user's chat privacy
+     */
+    public get chatPrivacy(): APIUserMessagePrivacy {
+        return this.get("messaging_privacy_status");
+    }
 
-	/**
-	 * Cover image background color
-	 */
-	public get coverColor(): string | null {
-		return this.get("cover_bg_color");
-	}
+    /**
+     * Cover image background color
+     */
+    public get coverColor(): string | null {
+        return this.get("cover_bg_color");
+    }
 
-	/**
-	 * Cover imamge url
-	 */
-	public get coverUrl(): string | null {
-		return this.get("cover_url");
-	}
+    /**
+     * Cover imamge url
+     */
+    public get coverUrl(): string | null {
+        return this.get("cover_url");
+    }
 
-	/**
-	 * Can the Client chat with the user?\
-	 * ? Not checked by the backend
-	 * @alias can_chat
-	 */
-	public get isAvailableForChat(): boolean {
-		return this.get("is_available_for_chat");
-	}
+    /**
+     * Can the Client chat with the user?\
+     * ? Not checked by the backend
+     * Alias for {@link canChat}
+     */
+    public get isAvailableForChat(): boolean {
+        return this.get("is_available_for_chat");
+    }
 
-	/**
-	 * Is the user banned?
-	 */
-	public get isBanned(): boolean {
-		return this.get("is_banned");
-	}
+    /**
+     * Is the user banned?
+     */
+    public get isBanned(): boolean {
+        return this.get("is_banned");
+    }
 
-	/**
-	 * Is the user blocked by the Client?
-	 */
-	public get isBlocked(): boolean {
-		return this.get("is_blocked");
-	}
+    /**
+     * Is the user blocked by the Client?
+     */
+    public get isBlocked(): boolean {
+        return this.get("is_blocked");
+    }
 
-	/**
-	 * Is the user deleted?
-	 */
-	public get isDeleted(): boolean {
-		return this.get("is_deleted");
-	}
+    /**
+     * Is the user deleted?
+     */
+    public get isDeleted(): boolean {
+        return this.get("is_deleted");
+    }
 
-	/**
-	 * Is the user's account private?
-	 */
-	public get isPrivate(): boolean {
-		return this.get("is_private");
-	}
+    /**
+     * Is the user's account private?
+     */
+    public get isPrivate(): boolean {
+        return this.get("is_private");
+    }
 
-	/**
-	 * Is the user subscribed to updates?
-	 */
-	public get isSubscribedToUpdates(): boolean {
-		return this.get("is_subscribed_to_updates");
-	}
+    /**
+     * Is the user subscribed to updates?
+     */
+    public get isSubscribedToUpdates(): boolean {
+        return this.get("is_subscribed_to_updates");
+    }
 
-	/**
-	 * Is the user subscribed to the Client?
-	 */
-	public get isSubscriber(): boolean {
-		return this.get("is_in_subscribers");
-	}
+    /**
+     * Is the user subscribed to the Client?
+     */
+    public get isSubscriber(): boolean {
+        return this.get("is_in_subscribers");
+    }
 
-	/**
-	 * Is the client subscribed to the user?
-	 */
-	public get isSubscription(): boolean {
-		return this.get("is_in_subscriptions");
-	}
+    /**
+     * Is the client subscribed to the user?
+     */
+    public get isSubscription(): boolean {
+        return this.get("is_in_subscriptions");
+    }
 
-	/**
-	 * Is the user verified?
-	 */
-	public get isVerified(): boolean {
-		return this.get("is_verified");
-	}
+    /**
+     * Is the user verified?
+     */
+    public get isVerified(): boolean {
+        return this.get("is_verified");
+    }
 
-	/**
-	 * The user's unique uri
-	 * @alias web_url
-	 */
-	public get link(): string {
-		return this.get("web_url");
-	}
+    /**
+     * The user's unique uri
+     * Alias for {@link webUrl}
+     */
+    public get link(): string {
+        return this.webUrl;
+    }
 
-	/**
-	 * The user's meme experience
-	 */
-	public get memeExperience(): MemeExperience {
-		return new MemeExperience(this.get("meme_experience"));
-	}
+    /**
+     * The user's unique uri
+     * Alias for {@link link}
+     */
+    public get webUrl(): string {
+        return this.get("web_url");
+    }
 
-	/**
-	 * TODO: Add description for messengerActive
-	 */
-	public get messengerActive(): boolean {
-		return this.get("messenger_active");
-	}
+    /**
+     * The user's meme experience
+     */
+    public get memeExperience(): MemeExperience {
+        return new MemeExperience(this.get("meme_experience"));
+    }
 
-	/**
-	 * TODO: Add description for messenger_token
-	 */
-	public get messengerToken(): string {
-		return this.get("messenger_token");
-	}
+    /**
+     * TODO: Add description for messengerActive
+     */
+    public get messengerActive(): boolean {
+        return this.get("messenger_active");
+    }
 
-	/**
-	 * Nickname of the user
-	 * @alias username
-	 */
-	public get nick(): string {
-		return this.get("nick");
-	}
+    /**
+     * TODO: Add description for messenger_token
+     */
+    public get messengerToken(): string {
+        return this.get("messenger_token");
+    }
 
-	/**
-	 * The nick color of the user if they have one, else null
-	 */
-	public get nickColor(): APINickColor | null {
-		return this.get("nick_color");
-	}
+    /**
+     * Nickname of the user
+     * Alias for {@link username}
+     */
+    public get nick(): string {
+        return this.get("nick");
+    }
 
-	/**
-	 * The users `num` object
-	 * @alias `stats`
-	 */
-	public get num(): APIUserProfileNums {
-		return this.get("num");
-	}
+    /**
+     * The nick color of the user if they have one, else null
+     */
+    public get nickColor(): APINickColor | null {
+        return this.get("nick_color");
+    }
 
-	/**
-	 * Profile photo of the user
-	 */
-	public get profilePhoto(): APIProfilePhoto | null {
-		return this.get("photo");
-	}
+    /**
+     * The users `num` object
+     * Alias for {@link stats}
+     */
+    public get num(): APIUserProfileNums {
+        return this.get("num");
+    }
 
-	/**
-	 * All the user's linked social media accounts
-	 */
-	public get socials(): APIUserAllSocials | null {
-		return this.get("social");
-	}
+    /**
+     * Profile photo of the user
+     */
+    public get profilePhoto(): APIProfilePhoto | null {
+        return this.get("photo");
+    }
 
-	/**
-	 * The users  `num` object
-	 * @alias num
-	 */
-	public get stats(): APIUserProfileNums {
-		return this.num;
-	}
+    /**
+     * All the user's linked social media accounts
+     */
+    public get socials(): APIUserAllSocials | null {
+        return this.get("social");
+    }
 
-	/**
-	 * The users subscription count
-	 */
-	public get totalSubscriptions(): number {
-		return this.num.subscriptions;
-	}
+    /**
+     * The users  `num` object
+     * Alias for {@link num}
+     */
+    public get stats(): APIUserProfileNums {
+        return this.num;
+    }
 
-	/**
-	 * The users subsciber count
-	 */
-	public get totalSubscribers(): number {
-		this.payload;
-		return this.num.subscribers;
-	}
+    /**
+     * The users subscription count
+     */
+    public get totalSubscriptions(): number {
+        return this.num.subscriptions;
+    }
 
-	/**
-	 * How many posts the user has on their profile
-	 */
-	public get totalPosts(): number {
-		return this.num.total_posts;
-	}
+    /**
+     * The users subsciber count
+     */
+    public get totalSubscribers(): number {
+        this.payload;
+        return this.num.subscribers;
+    }
 
-	/**
-	 * How many original posts the user has
-	 */
-	public get totalOriginalPosts(): number {
-		return this.num.created;
-	}
+    /**
+     * How many posts the user has on their profile
+     */
+    public get totalPosts(): number {
+        return this.num.total_posts;
+    }
 
-	/**
-	 * How many posts the has that are republishes (***NOT original***)
-	 */
-	public get totalRepublishedPosts(): number {
-		return this.totalPosts - this.totalOriginalPosts;
-	}
+    /**
+     * How many original posts the user has
+     */
+    public get totalOriginalPosts(): number {
+        return this.num.created;
+    }
 
-	/**
-	 * How many features the user has
-	 */
-	public get totalFeatures(): number {
-		return this.num.featured;
-	}
+    /**
+     * How many posts the has that are republishes (***NOT original***)
+     */
+    public get totalRepublishedPosts(): number {
+        return this.totalPosts - this.totalOriginalPosts;
+    }
 
-	/**
-	 * How many smiles the user has on their profile
-	 */
-	public get totalSmiles(): number {
-		return this.num.total_smiles;
-	}
+    /**
+     * How many features the user has
+     */
+    public get totalFeatures(): number {
+        return this.num.featured;
+    }
 
-	/**
-	 * How many achievements the user has
-	 */
-	public get totalAchievements(): number {
-		return this.num.achievements;
-	}
+    /**
+     * How many smiles the user has on their profile
+     */
+    public get totalSmiles(): number {
+        return this.num.total_smiles;
+    }
 
-	/**
-	 * Nickname of the user
-	 * @alias nick
-	 */
-	public get username(): string {
-		return this.nick;
-	}
+    /**
+     * How many achievements the user has
+     */
+    public get totalAchievements(): number {
+        return this.num.achievements;
+    }
 
-	/**
-	 * When concatenated with a string, this automatically returns the user's nick instead of the User object.
-	 * @example
-	 * console.log(`Hello from ${user}!`); //  Logs: Hello from iFunnyChef
-	 */
-	public override toString(): string {
-		return this.nick;
-	}
+    /**
+     * Nickname of the user
+     * Alias for {@link nick}
+     */
+    public get username(): string {
+        return this.nick;
+    }
+
+    /**
+     * When concatenated with a string, this automatically returns the user's nick instead of the User object.
+     * @example
+     * console.log(`Hello from ${user}!`); //  Logs: Hello from iFunnyChef
+     */
+    public override toString(): string {
+        return this.nick;
+    }
 }
 
 export default BaseUser;

--- a/src/structures/Cache.ts
+++ b/src/structures/Cache.ts
@@ -4,9 +4,9 @@ import { MemoryStorage } from "node-ts-cache-storage-memory";
 import type { Client } from "../client/Client";
 
 export type DataStructure = new (
-	client: Client,
-	payload: any,
-	...extra: any[]
+    client: Client,
+    payload: any,
+    ...extra: any[]
 ) => Base<any>;
 
 /**
@@ -15,52 +15,52 @@ export type DataStructure = new (
  * @extends CacheContainer
  */
 export class Cache<Holds extends DataStructure> extends CacheContainer {
-	readonly #holds: Holds;
-	#config: ICachingOptions;
-	public constructor(holds: Holds, config: ICachingOptions) {
-		super(new MemoryStorage());
-		this.#holds = holds;
-		this.#config = config;
-	}
+    readonly #holds: Holds;
+    #config: ICachingOptions;
+    public constructor(holds: Holds, config: ICachingOptions) {
+        super(new MemoryStorage());
+        this.#holds = holds;
+        this.#config = config;
+    }
 
-	/**
-	 * Cache Config this is using
-	 */
-	public get config() {
-		return this.#config;
-	}
+    /**
+     * Cache Config this is using
+     */
+    public get config() {
+        return this.#config;
+    }
 
-	/**
-	 * Class constructor that this Cache holds
-	 */
-	public get holds() {
-		return this.#holds;
-	}
+    /**
+     * Class constructor that this Cache holds
+     */
+    public get holds() {
+        return this.#holds;
+    }
 
-	/**
-	 * Fetches an item from the cache if it exists, else null
-	 * @param key Key for the item
-	 * @returns The item or null if it wasn't found
-	 */
-	public async get(key: string): Promise<InstanceType<Holds> | null> {
-		return (await this.getItem<InstanceType<Holds>>(key)) ?? null;
-	}
+    /**
+     * Fetches an item from the cache if it exists, else null
+     * @param key Key for the item
+     * @returns The item or null if it wasn't found
+     */
+    public async get(key: string): Promise<InstanceType<Holds> | null> {
+        return (await this.getItem<InstanceType<Holds>>(key)) ?? null;
+    }
 
-	/**
-	 * Sets an item in the cache
-	 * @param key Key for the item
-	 * @param value The item to cache
-	 * @param options The caching options to use
-	 * @returns this for method chaining
-	 */
-	public async set(
-		key: string,
-		value: InstanceType<Holds>,
-		options?: Partial<ICachingOptions>
-	): Promise<this> {
-		await this.setItem(key, value, options ?? this.config);
-		return this;
-	}
+    /**
+     * Sets an item in the cache
+     * @param key Key for the item
+     * @param value The item to cache
+     * @param options The caching options to use
+     * @returns this for method chaining
+     */
+    public async set(
+        key: string,
+        value: InstanceType<Holds>,
+        options?: Partial<ICachingOptions>,
+    ): Promise<this> {
+        await this.setItem(key, value, options ?? this.config);
+        return this;
+    }
 }
 
 export default Cache;

--- a/src/structures/Comment.ts
+++ b/src/structures/Comment.ts
@@ -9,13 +9,13 @@ import type { Content } from "./Content";
  * @extends BaseComment
  */
 export class Comment extends BaseComment {
-	/**
-	 * @param content Content attached to the Comment
-	 * @param payload Payload of the Comment
-	 */
-	public constructor(content: Content, payload: APIComment) {
-		super(content, payload);
-	}
+    /**
+     * @param content Content attached to the Comment
+     * @param payload Payload of the Comment
+     */
+    public constructor(content: Content, payload: APIComment) {
+        super(content, payload);
+    }
 }
 
 export default Comment;

--- a/src/structures/Content.ts
+++ b/src/structures/Content.ts
@@ -1,10 +1,10 @@
 import {
-	Endpoints,
-	type APIContent,
-	type APIFeedFrom,
-	type RESTAPIContentSmileResponse,
-	type RESTAPIContentSmileUsersResponse,
-	APIComment,
+    Endpoints,
+    type APIContent,
+    type APIFeedFrom,
+    type RESTAPIContentSmileResponse,
+    type RESTAPIContentSmileUsersResponse,
+    APIComment,
 } from "@ifunny/ifunny-api-types";
 import { BaseContent } from "./BaseContent";
 import { SimpleUser } from "./SimpleUser";
@@ -13,154 +13,155 @@ import type { Client } from "../client/Client";
 import type { URLSearchParams } from "url";
 
 export type ModifyParams =
-	| { from?: APIFeedFrom; limit?: number }
-	| URLSearchParams;
+    | { from?: APIFeedFrom; limit?: number }
+    | URLSearchParams;
 
 /**
  * Represents content from iFunny
  * @extends BaseContent
  */
 export class Content extends BaseContent {
-	/**
-	 * @param client Client attached to the Content
-	 * @param payload Payload of the content
-	 */
-	public constructor(client: Client, payload: APIContent) {
-		super(client, payload);
-	}
+    /**
+     * @param client Client attached to the Content
+     * @param payload Payload of the content
+     */
+    public constructor(client: Client, payload: APIContent) {
+        super(client, payload);
+    }
 
-	/**
-	 * Helper method to modify smiles for the content
-	 * @param method HTTP method
-	 * @param type `smiles` or `unsmiles`
-	 * @param params Params to pass to the request
-	 * @internal
-	 */
-	async #modifySmiles(
-		method: "PUT" | "DELETE",
-		type: "smiles" | "unsmiles",
-		params?: ModifyParams
-	): Promise<boolean> {
-		const response =
-			await this.client.instance.request<RESTAPIContentSmileResponse>({
-				method,
-				url: Endpoints[type](this.id),
-				params,
-			});
+    /**
+     * Helper method to modify smiles for the content
+     * @param method HTTP method
+     * @param type `smiles` or `unsmiles`
+     * @param params Params to pass to the request
+     * @internal
+     */
+    async #modifySmiles(
+        method: "PUT" | "DELETE",
+        type: "smiles" | "unsmiles",
+        params?: ModifyParams,
+    ): Promise<boolean> {
+        const response =
+            await this.client.instance.request<RESTAPIContentSmileResponse>({
+                method,
+                url: Endpoints[type](this.id),
+                params,
+            });
 
-		// Update payload
-		this.payload.num.smiles = response.data.data.num_smiles;
-		this.payload.num.unsmiles = response.data.data.num_unsmiles;
-		this.payload.num.guest_smiles = response.data.data.num_guest_smiles;
+        // Update payload
+        this.payload.num.smiles = response.data.data.num_smiles;
+        this.payload.num.unsmiles = response.data.data.num_unsmiles;
+        this.payload.num.guest_smiles = response.data.data.num_guest_smiles;
 
-		return response.data.status == 200;
-	}
+        return response.data.status == 200;
+    }
 
-	/**
-	 * Cycles through users that smiled the post
-	 * @param limit How many users to return per request (Default: `30`)
-	 */
-	public async *smiles(limit: number = 30) {
-		for await (const data of this.client.util.paginate<RESTAPIContentSmileUsersResponse>(
-			Endpoints.smiles(this.id),
-			"users",
-			{ limit },
-			true
-		)) {
-			for (const user of data.data.users.items) {
-				this.payload.num.smiles = data.data.smiles_count;
-				this.payload.num.guest_smiles = data.data.guest_smiles_count;
-				yield new SimpleUser(this.client, user);
-			}
-		}
-	}
+    /**
+     * Cycles through users that smiled the post
+     * @param limit How many users to return per request (Default: `30`)
+     */
+    public async *smiles(limit: number = 30) {
+        for await (const data of this.client.util.paginate<RESTAPIContentSmileUsersResponse>(
+            Endpoints.smiles(this.id),
+            "users",
+            { limit },
+            true,
+        )) {
+            for (const user of data.data.users.items) {
+                this.payload.num.smiles = data.data.smiles_count;
+                this.payload.num.guest_smiles = data.data.guest_smiles_count;
+                yield new SimpleUser(this.client, user);
+            }
+        }
+    }
 
-	/**
-	 * Smiles the post
-	 * @param from Where the action occured
-	 * @returns Was it success
-	 */
-	public async smile(from?: APIFeedFrom) {
-		return await this.#modifySmiles("PUT", "smiles", { from });
-	}
+    /**
+     * Smiles the post
+     * @param from Where the action occured
+     * @returns Was it success
+     */
+    public async smile(from?: APIFeedFrom) {
+        return await this.#modifySmiles("PUT", "smiles", { from });
+    }
 
-	/**
-	 * Removes the Client's smile
-	 * @param from Where the action occured
-	 * @returns Was it success
-	 */
-	public async removeSmile(from?: APIFeedFrom) {
-		return await this.#modifySmiles("DELETE", "smiles", { from });
-	}
+    /**
+     * Removes the Client's smile
+     * @param from Where the action occured
+     * @returns Was it success
+     */
+    public async removeSmile(from?: APIFeedFrom) {
+        return await this.#modifySmiles("DELETE", "smiles", { from });
+    }
 
-	/**
-	 * Unsmiles the post
-	 * @param from Where the action occured
-	 * @returns Was it success
-	 */
-	public async unsmile(from?: APIFeedFrom) {
-		return await this.#modifySmiles("PUT", "unsmiles", { from });
-	}
+    /**
+     * Unsmiles the post
+     * @param from Where the action occured
+     * @returns Was it success
+     */
+    public async unsmile(from?: APIFeedFrom) {
+        return await this.#modifySmiles("PUT", "unsmiles", { from });
+    }
 
-	/**
-	 * Removes the Client's unsmile
-	 * @param from Where the content was smiled
-	 * @returns Was the content marked as smiled
-	 */
-	public async removeUnsmile(from?: APIFeedFrom) {
-		return await this.#modifySmiles("DELETE", "unsmiles", { from });
-	}
+    /**
+     * Removes the Client's unsmile
+     * @param from Where the content was smiled
+     * @returns Was the content marked as smiled
+     */
+    public async removeUnsmile(from?: APIFeedFrom) {
+        return await this.#modifySmiles("DELETE", "unsmiles", { from });
+    }
 
-	/**
-	 * Attempts to delete the content
-	 * @returns Whether the attempt was successful
-	 */
-	public async delete(): Promise<boolean> {
-		if (!this.author?.id || !this.client.id) {
-			// console.log("Can't validate author or client");
-			return false;
-		}
+    /**
+     * Attempts to delete the content
+     * @returns Whether the attempt was successful
+     */
+    public async delete(): Promise<boolean> {
+        if (!this.author?.id || !this.client.id) {
+            // console.log("Can't validate author or client");
+            return false;
+        }
 
-		if (this.author.id !== this.client.id) {
-			// console.log("Author's don't match");
-			return false;
-		}
+        if (this.author.id !== this.client.id) {
+            // console.log("Author's don't match");
+            return false;
+        }
 
-		type ContentDeletionResponse = {
-			status: number;
-			data: {
-				retry_after: number;
-				id: string;
-				type: string;
-				state: string;
-			};
-		};
+        type ContentDeletionResponse = {
+            status: number;
+            data: {
+                retry_after: number;
+                id: string;
+                type: string;
+                state: string;
+            };
+        };
 
-		let response = await this.client.instance.request<ContentDeletionResponse>({
-			method: "DELETE",
-			url: Endpoints.content(this.id),
-		});
-		// console.log(response.data);
-		return response.data.status === 200;
-	}
+        const response =
+            await this.client.instance.request<ContentDeletionResponse>({
+                method: "DELETE",
+                url: Endpoints.content(this.id),
+            });
+        // console.log(response.data);
+        return response.data.status === 200;
+    }
 
-	/**
-	 * Paginate through the comments of the content
-	 * @param limit How many comments to return per request (Default: `30`)
-	 * @returns AsyncGenerator<Comment>
-	 */
-	async *comments(limit: number = 30): AsyncGenerator<Comment> {
-		for await (const comment of this.client.util.paginate<APIComment>(
-			Endpoints.comments(this.id),
-			"comments",
-			{
-				limit,
-			},
-			false
-		)) {
-			yield new Comment(this, comment);
-		}
-	}
+    /**
+     * Paginate through the comments of the content
+     * @param limit How many comments to return per request (Default: `30`)
+     * @returns AsyncGenerator<Comment>
+     */
+    async *comments(limit: number = 30): AsyncGenerator<Comment> {
+        for await (const comment of this.client.util.paginate<APIComment>(
+            Endpoints.comments(this.id),
+            "comments",
+            {
+                limit,
+            },
+            false,
+        )) {
+            yield new Comment(this, comment);
+        }
+    }
 }
 
 export default Content;

--- a/src/structures/Creator.ts
+++ b/src/structures/Creator.ts
@@ -2,11 +2,11 @@ import { Base } from "./Base";
 import type { Client } from "../client/Client";
 import type { User } from "./User";
 import type {
-	APIContentCreator,
-	APINickColor,
-	APIProfilePhoto,
-	APIUserNums,
-	APIUserRating,
+    APIContentCreator,
+    APINickColor,
+    APIProfilePhoto,
+    APIUserNums,
+    APIUserRating,
 } from "@ifunny/ifunny-api-types";
 
 /**
@@ -14,158 +14,158 @@ import type {
  * @extends Base<APIContentCreator>
  */
 export class Creator extends Base<APIContentCreator> {
-	/**
-	 * The Content Creator's User Object
-	 */
-	#user: User | null = null;
+    /**
+     * The Content Creator's User Object
+     */
+    #user: User | null = null;
 
-	/**
-	 * @param client Client instance for the Creator
-	 * @param payload Payload of the content creator
-	 */
-	public constructor(client: Client, payload: APIContentCreator) {
-		super(client, payload);
-	}
+    /**
+     * @param client Client instance for the Creator
+     * @param payload Payload of the content creator
+     */
+    public constructor(client: Client, payload: APIContentCreator) {
+        super(client, payload);
+    }
 
-	/**
-	 * The Content Creator's User Object
-	 * @returns Promise that resolves to the User Object
-	 */
-	public async user(): Promise<User> {
-		return (this.#user ??= await this.client.users.fetch(this.id))!;
-	}
+    /**
+     * The Content Creator's User Object
+     * @returns Promise that resolves to the User Object
+     */
+    public async user(): Promise<User> {
+        return (this.#user ??= await this.client.users.fetch(this.id))!;
+    }
 
-	/**
-	 * Is the creator banned?
-	 * @returns boolean
-	 */
-	public get isBanned(): boolean {
-		return this.get("is_banned");
-	}
+    /**
+     * Is the creator banned?
+     * @returns boolean
+     */
+    public get isBanned(): boolean {
+        return this.get("is_banned");
+    }
 
-	/**
-	 * Is the creator blocked by the Client?
-	 * @returns boolean
-	 */
-	public get isBlocked(): boolean {
-		return this.get("is_blocked");
-	}
+    /**
+     * Is the creator blocked by the Client?
+     * @returns boolean
+     */
+    public get isBlocked(): boolean {
+        return this.get("is_blocked");
+    }
 
-	/**
-	 * Is the creator a deleted user?
-	 * @returns boolean
-	 */
-	public get isDeleted(): boolean {
-		return this.get("is_deleted");
-	}
+    /**
+     * Is the creator a deleted user?
+     * @returns boolean
+     */
+    public get isDeleted(): boolean {
+        return this.get("is_deleted");
+    }
 
-	/**
-	 * Is the creator subscribed to the Client?
-	 * @returns boolean
-	 */
-	public get isSubscriber(): boolean {
-		return this.get("is_in_subscribers");
-	}
+    /**
+     * Is the creator subscribed to the Client?
+     * @returns boolean
+     */
+    public get isSubscriber(): boolean {
+        return this.get("is_in_subscribers");
+    }
 
-	/**
-	 * Is the Client subscribed to the Creator?
-	 * @returns boolean
-	 */
-	public get isSubscription(): boolean {
-		return this.get("is_in_subscriptions");
-	}
+    /**
+     * Is the Client subscribed to the Creator?
+     * @returns boolean
+     */
+    public get isSubscription(): boolean {
+        return this.get("is_in_subscriptions");
+    }
 
-	/**
-	 * Is the Creator verified?
-	 * @returns boolean
-	 */
-	public get isVerified(): boolean {
-		return this.get("is_verified");
-	}
+    /**
+     * Is the Creator verified?
+     * @returns boolean
+     */
+    public get isVerified(): boolean {
+        return this.get("is_verified");
+    }
 
-	/**
-	 * The creator's nick
-	 * @alias username
-	 */
-	public get nick(): string {
-		return this.get("nick");
-	}
+    /**
+     * The creator's nick
+     * Alias for {@link username}
+     */
+    public get nick(): string {
+        return this.get("nick");
+    }
 
-	/**
-	 * The creator's nick color
-	 * @returns A hex color code without the # prefix
-	 * @example
-	 * nick_color: "55FF00"
-	 */
-	public get nickColor(): APINickColor | null {
-		return this.get("nick_color");
-	}
+    /**
+     * The creator's nick color
+     * @returns A hex color code without the # prefix
+     * @example
+     * nick_color: "55FF00"
+     */
+    public get nickColor(): APINickColor | null {
+        return this.get("nick_color");
+    }
 
-	/**
-	 * The creator's nums
-	 * @alias stats
-	 */
-	public get num(): APIUserNums {
-		return this.get("num");
-	}
+    /**
+     * The creator's nums
+     * Alias for {@link stats}
+     */
+    public get num(): APIUserNums {
+        return this.get("num");
+    }
 
-	/**
-	 * The creator's original nick\
-	 * ? iFunny sometimes censors users nicknames
-	 * @example
-	 * nick: "garespectingyoass"
-	 * original_nick: "garapingyoass"
-	 */
-	public get originalNick(): string {
-		return this.get("original_nick");
-	}
+    /**
+     * The creator's original nick\
+     * ? iFunny sometimes censors users nicknames
+     * @example
+     * nick: "garespectingyoass"
+     * original_nick: "garapingyoass"
+     */
+    public get originalNick(): string {
+        return this.get("original_nick");
+    }
 
-	/**
-	 * The creator's profile photo
-	 */
-	public get photo(): APIProfilePhoto | null {
-		return this.get("photo");
-	}
+    /**
+     * The creator's profile photo
+     */
+    public get photo(): APIProfilePhoto | null {
+        return this.get("photo");
+    }
 
-	/**
-	 * The creator's rating
-	 */
-	public get rating(): APIUserRating {
-		return this.get("rating");
-	}
+    /**
+     * The creator's rating
+     */
+    public get rating(): APIUserRating {
+        return this.get("rating");
+    }
 
-	/**
-	 * The creator's stats
-	 * @alias num
-	 */
-	public get stats(): APIUserNums {
-		return this.num;
-	}
+    /**
+     * The creator's stats
+     * Alias for {@link num}
+     */
+    public get stats(): APIUserNums {
+        return this.num;
+    }
 
-	/**
-	 * Total number of posts the creator has\
-	 * ? This isn't in Creator.num for some reason
-	 */
-	public get totalPosts(): number {
-		return this.get("total_posts");
-	}
+    /**
+     * Total number of posts the creator has\
+     * ? This isn't in Creator.num for some reason
+     */
+    public get totalPosts(): number {
+        return this.get("total_posts");
+    }
 
-	/**
-	 * The creator's username
-	 * @alias nick
-	 */
-	public get username(): string {
-		return this.nick;
-	}
+    /**
+     * The creator's username
+     * Alias for {@link nick}
+     */
+    public get username(): string {
+        return this.nick;
+    }
 
-	/**
-	 * When concatenated with a string, this automatically returns the user's nick instead of the User object.
-	 * @example
-	 * console.log(`Hello from ${user}!`); //  Logs: Hello from iFunnyChef
-	 */
-	public override toString(): string {
-		return this.nick;
-	}
+    /**
+     * When concatenated with a string, this automatically returns the user's nick instead of the User object.
+     * @example
+     * console.log(`Hello from ${user}!`); //  Logs: Hello from iFunnyChef
+     */
+    public override toString(): string {
+        return this.nick;
+    }
 }
 
 export default Creator;

--- a/src/structures/Feed.ts
+++ b/src/structures/Feed.ts
@@ -8,35 +8,35 @@ import type { Client } from "../client/Client";
  * @extends BaseFeed
  */
 export class Feed extends BaseFeed {
-	/**
-	 * @param client Client attached to the Feed
-	 * @param url Url for the feed
-	 */
-	public constructor(client: Client, url: string) {
-		super(client, url);
-	}
+    /**
+     * @param client Client attached to the Feed
+     * @param url Url for the feed
+     */
+    public constructor(client: Client, url: string) {
+        super(client, url);
+    }
 
-	/**
-	 * Scrolls through content in a feed from left to right
-	 * @param params Params to pass into the pagination requests - Updates automatically
-	 * @param markAsRead Should each post be marked as read after viewing? (Default: false)
-	 */
-	public async *scroll(params?: PaginateConfig, markAsRead: boolean = false) {
-		for await (const api_content of this.client.util.paginate<APIContent>(
-			this.url,
-			"content",
-			Object.assign({ limit: 30 }, params)
-		)) {
-			if (markAsRead) {
-				this.client.content.markAsRead(api_content.id);
-			}
-			const content = new Content(this.client, api_content);
+    /**
+     * Scrolls through content in a feed from left to right
+     * @param params Params to pass into the pagination requests - Updates automatically
+     * @param markAsRead Should each post be marked as read after viewing? (Default: false)
+     */
+    public async *scroll(params?: PaginateConfig, markAsRead: boolean = false) {
+        for await (const api_content of this.client.util.paginate<APIContent>(
+            this.url,
+            "content",
+            Object.assign({ limit: 30 }, params),
+        )) {
+            if (markAsRead) {
+                this.client.content.markAsRead(api_content.id);
+            }
+            const content = new Content(this.client, api_content);
 
-			this.client.content.cache.set(content.id, content);
+            this.client.content.cache.set(content.id, content);
 
-			yield content;
-		}
-	}
+            yield content;
+        }
+    }
 }
 
 export default Feed;

--- a/src/structures/MemeExperience.ts
+++ b/src/structures/MemeExperience.ts
@@ -1,65 +1,69 @@
-import type { APIMemeExperience, APIMemeRank, Size } from "@ifunny/ifunny-api-types";
+import type {
+    APIMemeExperience,
+    APIMemeRank,
+    Size,
+} from "@ifunny/ifunny-api-types";
 
 /**
  * The Meme Experience for a user
  */
 export class MemeExperience {
-	/**
-	 * Raw data from the API
-	 */
-	protected data: APIMemeExperience;
+    /**
+     * Raw data from the API
+     */
+    protected data: APIMemeExperience;
 
-	/**
-	 * @param data The raw api data for the meme experience
-	 */
-	public constructor(data: APIMemeExperience) {
-		this.data = data;
-	}
+    /**
+     * @param data The raw api data for the meme experience
+     */
+    public constructor(data: APIMemeExperience) {
+        this.data = data;
+    }
 
-	/**
-	 * The user's rank
-	 */
-	public get rank(): APIMemeRank {
-		return this.data.rank;
-	}
+    /**
+     * The user's rank
+     */
+    public get rank(): APIMemeRank {
+        return this.data.rank;
+    }
 
-	/**
-	 * How many days the user has spent logged in
-	 */
-	public get days(): number {
-		return this.data.days;
-	}
+    /**
+     * How many days the user has spent logged in
+     */
+    public get days(): number {
+        return this.data.days;
+    }
 
-	/**
-	 * Url of the badge
-	 * @example
-	 * `https://img.ifunny.co/meme_experience/${number}.png`
-	 */
-	public get badgeUrl(): string {
-		return this.data.badge_url;
-	}
+    /**
+     * Url of the badge
+     * @example
+     * `https://img.ifunny.co/meme_experience/${number}.png`
+     */
+    public get badgeUrl(): string {
+        return this.data.badge_url;
+    }
 
-	/**
-	 * Size of the badge
-	 */
-	public get badgeSize(): Size {
-		return this.data.badge_size;
-	}
+    /**
+     * Size of the badge
+     */
+    public get badgeSize(): Size {
+        return this.data.badge_size;
+    }
 
-	/**
-	 * Days needed to get the next rank\
-	 * ? Chef's Meme Agent will show 3000 but does not change when it reaches it
-	 */
-	public get nextMilestone(): number {
-		return this.data.next_milestone;
-	}
+    /**
+     * Days needed to get the next rank\
+     * ? Chef's Meme Agent will show 3000 but does not change when it reaches it
+     */
+    public get nextMilestone(): number {
+        return this.data.next_milestone;
+    }
 
-	/**
-	 * Days until the user reaches the next milestone
-	 */
-	public get daysUntilNextMilestone(): number {
-		return this.nextMilestone - this.days;
-	}
+    /**
+     * Days until the user reaches the next milestone
+     */
+    public get daysUntilNextMilestone(): number {
+        return this.nextMilestone - this.days;
+    }
 }
 
 export default MemeExperience;

--- a/src/structures/News.ts
+++ b/src/structures/News.ts
@@ -1,11 +1,11 @@
 import type {
-	APIBanType,
-	APIComment,
-	APIContent,
-	APIMentionUser,
-	APINews,
-	APINewsType,
-	APINewsUser,
+    APIBanType,
+    APIComment,
+    APIContent,
+    APIMentionUser,
+    APINews,
+    APINewsType,
+    APINewsUser,
 } from "@ifunny/ifunny-api-types";
 import type { Nullify } from "../utils/Types";
 import Content from "./Content";
@@ -15,196 +15,196 @@ import Client from "../client/Client";
  * Represents a News object from the Activity Feed
  */
 export class News {
-	readonly #payload: APINews;
-	readonly #client: Client;
-	/**
-	 * @param client The Client associated with the News
-	 * @param news Payload of the News Object
-	 */
-	public constructor(client: Client, news: APINews) {
-		this.#payload = news;
-		this.#client = client;
-	}
+    readonly #payload: APINews;
+    readonly #client: Client;
+    /**
+     * @param client The Client associated with the News
+     * @param news Payload of the News Object
+     */
+    public constructor(client: Client, news: APINews) {
+        this.#payload = news;
+        this.#client = client;
+    }
 
-	/**
-	 * The Client associated with the News
-	 */
-	public get client(): Client {
-		return this.#client;
-	}
+    /**
+     * The Client associated with the News
+     */
+    public get client(): Client {
+        return this.#client;
+    }
 
-	/**
-	 * Payload of the News
-	 */
-	public get payload() {
-		return this.#payload;
-	}
+    /**
+     * Payload of the News
+     */
+    public get payload() {
+        return this.#payload;
+    }
 
-	/**
-	 * Get the value of a property of the News object from the payload
-	 * @param key Key of the property
-	 * @returns The value of the property
-	 */
-	protected get<K extends keyof APINews>(key: K): Nullify<APINews[K]> {
-		return (this.payload[key] ?? null) as Nullify<APINews[K]>;
-	}
+    /**
+     * Get the value of a property of the News object from the payload
+     * @param key Key of the property
+     * @returns The value of the property
+     */
+    protected get<K extends keyof APINews>(key: K): Nullify<APINews[K]> {
+        return (this.payload[key] ?? null) as Nullify<APINews[K]>;
+    }
 
-	/**
-	 * The Date of the News object
-	 */
-	public get date(): Date {
-		return new Date(this.get("date") * 1000);
-	}
+    /**
+     * The Date of the News object
+     */
+    public get date(): Date {
+        return new Date(this.get("date") * 1000);
+    }
 
-	/**
-	 * The type of the News object
-	 */
-	public get type(): APINewsType {
-		return this.get("type");
-	}
+    /**
+     * The type of the News object
+     */
+    public get type(): APINewsType {
+        return this.get("type");
+    }
 
-	/**
-	 * The ID of the Ban associated with the News object
-	 */
-	public get banId(): string | null {
-		return this.get("banId");
-	}
+    /**
+     * The ID of the Ban associated with the News object
+     */
+    public get banId(): string | null {
+        return this.get("banId");
+    }
 
-	/**
-	 * The message associated with the Ban associated with the News object
-	 */
-	public get banMessage(): string | null {
-		return this.get("banTypeMessage");
-	}
+    /**
+     * The message associated with the Ban associated with the News object
+     */
+    public get banMessage(): string | null {
+        return this.get("banTypeMessage");
+    }
 
-	/**
-	 * The type of the Ban associated with the News object
-	 */
-	public get banType(): APIBanType | null {
-		return this.get("banType");
-	}
+    /**
+     * The type of the Ban associated with the News object
+     */
+    public get banType(): APIBanType | null {
+        return this.get("banType");
+    }
 
-	/**
-	 * The raw comment associated with the News object
-	 */
-	public get comment(): APIComment | null {
-		return this.get("comment");
-	}
+    /**
+     * The raw comment associated with the News object
+     */
+    public get comment(): APIComment | null {
+        return this.get("comment");
+    }
 
-	/**
-	 * The content associated with the News object
-	 */
-	public get content(): APIContent | null {
-		return this.get("content");
-	}
+    /**
+     * The content associated with the News object
+     */
+    public get content(): APIContent | null {
+        return this.get("content");
+    }
 
-	/**
-	 * The current number of active strikes for the Client
-	 */
-	public get countActiveStrike(): number | null {
-		return this.get("countActiveStrike");
-	}
+    /**
+     * The current number of active strikes for the Client
+     */
+    public get countActiveStrike(): number | null {
+        return this.get("countActiveStrike");
+    }
 
-	/**
-	 * The date that the Ban or Strike will expire
-	 */
-	public get dateUntil(): Date | null {
-		const date = this.get("date_until");
-		return date ? new Date(date * 1000) : null;
-	}
+    /**
+     * The date that the Ban or Strike will expire
+     */
+    public get dateUntil(): Date | null {
+        const date = this.get("date_until");
+        return date ? new Date(date * 1000) : null;
+    }
 
-	/**
-	 * The date that the Ban or Strike expired
-	 */
-	public get expiredAt(): Date | null {
-		const date = this.get("expiredAt");
-		return date ? new Date(date * 1000) : null;
-	}
+    /**
+     * The date that the Ban or Strike expired
+     */
+    public get expiredAt(): Date | null {
+        const date = this.get("expiredAt");
+        return date ? new Date(date * 1000) : null;
+    }
 
-	/**
-	 * The URL of the image associated with the News object
-	 */
-	public get imageUrl(): string | null {
-		return this.get("imageUrl");
-	}
+    /**
+     * The URL of the image associated with the News object
+     */
+    public get imageUrl(): string | null {
+        return this.get("imageUrl");
+    }
 
-	/**
-	 * The Content mentioned in this news object
-	 */
-	public get mentionContent() {
-		const content = this.get("mention_content");
-		return content ? new Content(this.client, content) : null;
-	}
+    /**
+     * The Content mentioned in this news object
+     */
+    public get mentionContent() {
+        const content = this.get("mention_content");
+        return content ? new Content(this.client, content) : null;
+    }
 
-	/**
-	 * The users mentioned in this news object
-	 */
-	public get mentionUsers(): APIMentionUser[] | null {
-		return this.get("mention_users");
-	}
+    /**
+     * The users mentioned in this news object
+     */
+    public get mentionUsers(): APIMentionUser[] | null {
+        return this.get("mention_users");
+    }
 
-	/**
-	 * The type of purchase associated with the News object
-	 */
-	public get purchaseType(): string | null {
-		return this.get("purchaseType");
-	}
+    /**
+     * The type of purchase associated with the News object
+     */
+    public get purchaseType(): string | null {
+        return this.get("purchaseType");
+    }
 
-	/**
-	 * The raw reply associated with the News object
-	 */
-	public get reply(): APIComment | null {
-		return this.get("reply");
-	}
+    /**
+     * The raw reply associated with the News object
+     */
+    public get reply(): APIComment | null {
+        return this.get("reply");
+    }
 
-	/**
-	 * The number of smiles associated with the News object
-	 */
-	public get smiles(): number | null {
-		return this.get("smiles");
-	}
+    /**
+     * The number of smiles associated with the News object
+     */
+    public get smiles(): number | null {
+        return this.get("smiles");
+    }
 
-	/**
-	 * The ID of the strike associated with the News object
-	 */
-	public get strikeId(): string | null {
-		return this.get("strikeId");
-	}
+    /**
+     * The ID of the strike associated with the News object
+     */
+    public get strikeId(): string | null {
+        return this.get("strikeId");
+    }
 
-	/**
-	 * The message associated with the strike associated with the News object
-	 */
-	public get text(): string | null {
-		return this.get("text");
-	}
+    /**
+     * The message associated with the strike associated with the News object
+     */
+    public get text(): string | null {
+        return this.get("text");
+    }
 
-	/**
-	 * The title of the News object
-	 */
-	public get title(): string | null {
-		return this.get("title");
-	}
+    /**
+     * The title of the News object
+     */
+    public get title(): string | null {
+        return this.get("title");
+    }
 
-	/**
-	 * The URL of the News object
-	 */
-	public get url(): string | null {
-		return this.get("url");
-	}
+    /**
+     * The URL of the News object
+     */
+    public get url(): string | null {
+        return this.get("url");
+    }
 
-	/**
-	 * The User associated with the News object
-	 */
-	public get user(): APINewsUser | null {
-		return this.get("user");
-	}
+    /**
+     * The User associated with the News object
+     */
+    public get user(): APINewsUser | null {
+        return this.get("user");
+    }
 
-	/**
-	 * The username associated with the News object
-	 */
-	public get username(): string | null {
-		return this.get("username");
-	}
+    /**
+     * The username associated with the News object
+     */
+    public get username(): string | null {
+        return this.get("username");
+    }
 }
 
 export default News;

--- a/src/structures/SimpleUser.ts
+++ b/src/structures/SimpleUser.ts
@@ -1,9 +1,9 @@
 import {
-	Endpoints,
-	type APICommentAuthor,
-	type APIProfilePhoto,
-	type APISimpleUser,
-	type APIUserNums,
+    Endpoints,
+    type APICommentAuthor,
+    type APIProfilePhoto,
+    type APISimpleUser,
+    type APIUserNums,
 } from "@ifunny/ifunny-api-types";
 import { Base } from "./Base";
 import type { Client } from "../client/Client";
@@ -14,145 +14,148 @@ import type { User } from "./User";
  * @extends Base<APISimpleUser>
  */
 export class SimpleUser extends Base<APISimpleUser> {
-	/**
-	 * Cached user to prevent multiple API calls
-	 */
-	#user: User | null = null;
+    /**
+     * Cached user to prevent multiple API calls
+     */
+    #user: User | null = null;
 
-	/**
-	 * @param client Client attached to the SimpleUser
-	 * @param payload Payload for the SimpleUser
-	 */
-	public constructor(client: Client, payload: APISimpleUser | APICommentAuthor) {
-		super(client, payload);
-		this.endpointUrl = Endpoints.user(this.id);
-	}
+    /**
+     * @param client Client attached to the SimpleUser
+     * @param payload Payload for the SimpleUser
+     */
+    public constructor(
+        client: Client,
+        payload: APISimpleUser | APICommentAuthor,
+    ) {
+        super(client, payload);
+        this.endpointUrl = Endpoints.user(this.id);
+    }
 
-	/**
-	 * Fetches the User object
-	 * @returns The User object with more information
-	 */
-	public async user(): Promise<User | null> {
-		return (this.#user ??= await this.client.users.fetch(this.id));
-	}
+    /**
+     * Fetches the User object
+     * @returns The User object with more information
+     */
+    public async user(): Promise<User | null> {
+        return (this.#user ??= await this.client.users.fetch(this.id));
+    }
 
-	/**
-	 * Is the user banned?
-	 */
-	public get isBanned(): boolean {
-		return this.get("is_banned");
-	}
+    /**
+     * Is the user banned?
+     */
+    public get isBanned(): boolean {
+        return this.get("is_banned");
+    }
 
-	/**
-	 * Is the user blocked by the Client?
-	 */
-	public get isBlocked(): boolean {
-		return this.get("is_blocked");
-	}
+    /**
+     * Is the user blocked by the Client?
+     */
+    public get isBlocked(): boolean {
+        return this.get("is_blocked");
+    }
 
-	/**
-	 * Is the user deleted?
-	 */
-	public get isDeleted(): boolean {
-		return this.get("is_deleted");
-	}
+    /**
+     * Is the user deleted?
+     */
+    public get isDeleted(): boolean {
+        return this.get("is_deleted");
+    }
 
-	/**
-	 * Is the user subcribed to the Client?
-	 */
-	public get isSubscriber(): boolean {
-		return this.get("is_in_subscribers");
-	}
+    /**
+     * Is the user subcribed to the Client?
+     */
+    public get isSubscriber(): boolean {
+        return this.get("is_in_subscribers");
+    }
 
-	/**
-	 * Is the Cilent subscribed to the user?
-	 */
-	public get isSubscription(): boolean {
-		return this.get("is_in_subscriptions");
-	}
+    /**
+     * Is the Cilent subscribed to the user?
+     */
+    public get isSubscription(): boolean {
+        return this.get("is_in_subscriptions");
+    }
 
-	/**
-	 * Is the user verified?
-	 */
-	public get isVerified(): boolean {
-		return this.get("is_verified");
-	}
+    /**
+     * Is the user verified?
+     */
+    public get isVerified(): boolean {
+        return this.get("is_verified");
+    }
 
-	/**
-	 * User's nick
-	 * @alias username
-	 */
-	public get nick(): string {
-		return this.get("nick");
-	}
+    /**
+     * User's nick
+     * Alias for {@link username}
+     */
+    public get nick(): string {
+        return this.get("nick");
+    }
 
-	/**
-	 * Nums for the user
-	 * @alias stats
-	 */
-	public get num(): APIUserNums {
-		return this.get("num");
-	}
+    /**
+     * Nums for the user
+     * Alias for {@link stats}
+     */
+    public get num(): APIUserNums {
+        return this.get("num");
+    }
 
-	/**
-	 * Original nick for the user
-	 */
-	public get originalNick(): string {
-		return this.get("original_nick");
-	}
+    /**
+     * Original nick for the user
+     */
+    public get originalNick(): string {
+        return this.get("original_nick");
+    }
 
-	/**
-	 * Profile photo for the user
-	 */
-	public get photo(): APIProfilePhoto | null {
-		return this.get("photo");
-	}
+    /**
+     * Profile photo for the user
+     */
+    public get photo(): APIProfilePhoto | null {
+        return this.get("photo");
+    }
 
-	/**
-	 * Stats for the user
-	 * @alias num
-	 */
-	public get stats(): APIUserNums {
-		return this.num;
-	}
+    /**
+     * Stats for the user
+     * Alias for {@link num}
+     */
+    public get stats(): APIUserNums {
+        return this.num;
+    }
 
-	/**
-	 * Amount of posts the user has
-	 */
-	public get totalPosts(): number {
-		return this.get("total_posts");
-	}
+    /**
+     * Amount of posts the user has
+     */
+    public get totalPosts(): number {
+        return this.get("total_posts");
+    }
 
-	/**
-	 * Amount of subscribers the user has
-	 */
-	public get totalSubscribers(): number {
-		return this.num.subscribers;
-	}
+    /**
+     * Amount of subscribers the user has
+     */
+    public get totalSubscribers(): number {
+        return this.num.subscribers;
+    }
 
-	/**
-	 * Amount of subcriptions the user has
-	 */
-	public get totalSubscriptions(): number {
-		return this.num.subscriptions;
-	}
+    /**
+     * Amount of subcriptions the user has
+     */
+    public get totalSubscriptions(): number {
+        return this.num.subscriptions;
+    }
 
-	/**
-	 * User's nick
-	 * @alias nick
-	 */
-	public get username(): string {
-		return this.nick;
-	}
+    /**
+     * User's nick
+     * Alias for {@link nick}
+     */
+    public get username(): string {
+        return this.nick;
+    }
 
-	/**
-	 * When concatenated with a string, this automatically returns the user's nick instead of the User object.
-	 * @example
-	 * console.log(`Hello from ${user}!`); //  Logs: Hello from iFunnyChef
-	 */
-	public override toString(): string {
-		return this.nick;
-	}
+    /**
+     * When concatenated with a string, this automatically returns the user's nick instead of the User object.
+     * @example
+     * console.log(`Hello from ${user}!`); //  Logs: Hello from iFunnyChef
+     */
+    public override toString(): string {
+        return this.nick;
+    }
 }
 
 export default SimpleUser;

--- a/src/structures/Thumbnail.ts
+++ b/src/structures/Thumbnail.ts
@@ -4,139 +4,141 @@ import type { APIContentThumbnail, Size } from "@ifunny/ifunny-api-types";
  * Represents a thumbnail for Content on iFunny
  */
 export class Thumbnail {
-	#thumb: APIContentThumbnail;
+    #thumb: APIContentThumbnail;
 
-	/**
-	 * The regex used to find the thumbnail ID
-	 */
-	static readonly Thumbnail_ID_Regex =
-		/(?<=^https\:\/\/imageproxy\.ifunny\.co\/[a-z0-9:,-]+\/[a-z]+\/)([a-z0-9_]+)(?=\.[a-z]{3,4}$)/gi;
+    /**
+     * The regex used to find the thumbnail ID
+     */
+    static readonly Thumbnail_ID_Regex =
+        /(?<=^https\:\/\/imageproxy\.ifunny\.co\/[a-z0-9:,-]+\/[a-z]+\/)([a-z0-9_]+)(?=\.[a-z]{3,4}$)/gi;
 
-	/**
-	 * @param thumbnail Thumbnail data from the API
-	 */
-	public constructor(thumbnail: APIContentThumbnail) {
-		this.#thumb = thumbnail;
-	}
+    /**
+     * @param thumbnail Thumbnail data from the API
+     */
+    public constructor(thumbnail: APIContentThumbnail) {
+        this.#thumb = thumbnail;
+    }
 
-	/**
-	 * Gets the value for the thumbnail from its key
-	 * @param key Key for the thumbnail
-	 * @returns Type safe value from the key
-	 */
-	protected get<K extends keyof APIContentThumbnail>(key: K): APIContentThumbnail[K] {
-		return this.#thumb[key];
-	}
+    /**
+     * Gets the value for the thumbnail from its key
+     * @param key Key for the thumbnail
+     * @returns Type safe value from the key
+     */
+    protected get<K extends keyof APIContentThumbnail>(
+        key: K,
+    ): APIContentThumbnail[K] {
+        return this.#thumb[key];
+    }
 
-	/**
-	 * Gets the ID of the thumbnail from its URL.
-	 * @throws An error if the ID cannot be found in the URL.
-	 * @returns The ID string.
-	 */
-	public get id(): string {
-		const id = this.url.match(Thumbnail.Thumbnail_ID_Regex);
-		if (!id) {
-			throw new Error(
-				`Thumbnail Id Regex too specific. Couldn't get ID for: ${this.url}`
-			);
-		}
-		return id[0];
-	}
+    /**
+     * Gets the ID of the thumbnail from its URL.
+     * @throws An error if the ID cannot be found in the URL.
+     * @returns The ID string.
+     */
+    public get id(): string {
+        const id = this.url.match(Thumbnail.Thumbnail_ID_Regex);
+        if (!id) {
+            throw new Error(
+                `Thumbnail Id Regex too specific. Couldn't get ID for: ${this.url}`,
+            );
+        }
+        return id[0];
+    }
 
-	/**
-	 * Create a new thumbnail with custom parameters
-	 * @param params Params for the new thumbnail
-	 * @param extension File extension for the thumbnail. (Default: `jpg`)
-	 */
-	public create(params: string, extension: "jpg" | " webp" = "jpg"): string {
-		return `https://imageproxy.ifunny.co/${params}/images/${this.id}.${extension}`;
-	}
+    /**
+     * Create a new thumbnail with custom parameters
+     * @param params Params for the new thumbnail
+     * @param extension File extension for the thumbnail. (Default: `jpg`)
+     */
+    public create(params: string, extension: "jpg" | " webp" = "jpg"): string {
+        return `https://imageproxy.ifunny.co/${params}/images/${this.id}.${extension}`;
+    }
 
-	/**
-	 * The content url after cropping out the iFunny Watermark
-	 */
-	public get cropped(): string {
-		return this.create("crop:x-20");
-	}
-	/**
-	 * Gets the large image URL.
-	 * @returns The URL string or null if not available.
-	 */
-	public get largeUrl(): string {
-		return this.get("large_url") ?? null;
-	}
+    /**
+     * The content url after cropping out the iFunny Watermark
+     */
+    public get cropped(): string {
+        return this.create("crop:x-20");
+    }
+    /**
+     * Gets the large image URL.
+     * @returns The URL string or null if not available.
+     */
+    public get largeUrl(): string {
+        return this.get("large_url") ?? null;
+    }
 
-	/**
-	 * Gets the large WebP image URL.
-	 * @returns The URL string or null if not available.
-	 */
-	public get largeWebpUrl(): string {
-		return this.get("large_webp_url") ?? null;
-	}
+    /**
+     * Gets the large WebP image URL.
+     * @returns The URL string or null if not available.
+     */
+    public get largeWebpUrl(): string {
+        return this.get("large_webp_url") ?? null;
+    }
 
-	/**
-	 * Gets the proportional size of the image.
-	 * @returns The size object or null if not available.
-	 */
-	public get proportionalSize(): Size {
-		return this.get("proportional_size") ?? null;
-	}
+    /**
+     * Gets the proportional size of the image.
+     * @returns The size object or null if not available.
+     */
+    public get proportionalSize(): Size {
+        return this.get("proportional_size") ?? null;
+    }
 
-	/**
-	 * Gets the proportional image URL.
-	 * @returns The URL string or null if not available.
-	 */
-	public get proportionalUrl(): string {
-		return this.get("proportional_url") ?? null;
-	}
+    /**
+     * Gets the proportional image URL.
+     * @returns The URL string or null if not available.
+     */
+    public get proportionalUrl(): string {
+        return this.get("proportional_url") ?? null;
+    }
 
-	/**
-	 * Gets the proportional WebP image URL.
-	 * @returns The URL string or null if not available.
-	 */
-	public get proportionalWebpUrl(): string {
-		return this.get("proportional_webp_url") ?? null;
-	}
+    /**
+     * Gets the proportional WebP image URL.
+     * @returns The URL string or null if not available.
+     */
+    public get proportionalWebpUrl(): string {
+        return this.get("proportional_webp_url") ?? null;
+    }
 
-	/**
-	 * Gets the small image URL.
-	 * @returns The URL string or null if not available.
-	 */
-	public get smallUrl(): string | null {
-		return this.get("small_url") ?? null;
-	}
+    /**
+     * Gets the small image URL.
+     * @returns The URL string or null if not available.
+     */
+    public get smallUrl(): string | null {
+        return this.get("small_url") ?? null;
+    }
 
-	/**
-	 * Gets the image URL.
-	 * @returns The URL string or null if not available.
-	 */
-	public get url(): string {
-		return this.get("url") ?? null;
-	}
+    /**
+     * Gets the image URL.
+     * @returns The URL string or null if not available.
+     */
+    public get url(): string {
+        return this.get("url") ?? null;
+    }
 
-	/**
-	 * Gets the WebP image URL.
-	 * @returns The URL string or null if not available.
-	 */
-	public get webpUrl(): string {
-		return this.get("webp_url") ?? null;
-	}
+    /**
+     * Gets the WebP image URL.
+     * @returns The URL string or null if not available.
+     */
+    public get webpUrl(): string {
+        return this.get("webp_url") ?? null;
+    }
 
-	/**
-	 * Gets the 640px wide image URL.
-	 * @returns The URL string or null if not available.
-	 */
-	public get x640Url(): string {
-		return this.get("x640_url") ?? null;
-	}
+    /**
+     * Gets the 640px wide image URL.
+     * @returns The URL string or null if not available.
+     */
+    public get x640Url(): string {
+        return this.get("x640_url") ?? null;
+    }
 
-	/**
-	 * Gets the 640px wide WebP image URL.
-	 * @returns The URL string or null if not available.
-	 */
-	public get x640WebpUrl(): string {
-		return this.get("x640_webp_url") ?? null;
-	}
+    /**
+     * Gets the 640px wide WebP image URL.
+     * @returns The URL string or null if not available.
+     */
+    public get x640WebpUrl(): string {
+        return this.get("x640_webp_url") ?? null;
+    }
 }
 
 export default Thumbnail;

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -1,4 +1,8 @@
-import { type APIUserProfile, Endpoints, IFUNNY_ERRORS } from "@ifunny/ifunny-api-types";
+import {
+    type APIUserProfile,
+    Endpoints,
+    IFUNNY_ERRORS,
+} from "@ifunny/ifunny-api-types";
 import { BaseUser } from "./BaseUser";
 import { iFunnyError } from "../errors/iFunnyError";
 import Feed from "./Feed";
@@ -9,65 +13,66 @@ import type { Client } from "../client/Client";
  * @extends BaseUser
  */
 export class User extends BaseUser {
-	#timeline: Feed | null = null;
+    #timeline: Feed | null = null;
 
-	/**
-	 * @param client Client instance associated with the User
-	 * @param payload Payload of the User
-	 */
-	public constructor(client: Client, payload: APIUserProfile) {
-		super(client, payload);
-	}
+    /**
+     * @param client Client instance associated with the User
+     * @param payload Payload of the User
+     */
+    public constructor(client: Client, payload: APIUserProfile) {
+        super(client, payload);
+    }
 
-	/**
-	 * Modify the subscription status of the User
-	 * @param method "PUT" or "DELETE"
-	 */
-	async #modifySubscription(method: "PUT" | "DELETE"): Promise<this> {
-		if (!this.client.isAuthorized()) {
-			throw new iFunnyError(this.client, {
-				error: IFUNNY_ERRORS.UNAUTHORIZED,
-				error_description: "Requested operation is unavailable for guests",
-				status: 400,
-			});
-		}
+    /**
+     * Modify the subscription status of the User
+     * @param method "PUT" or "DELETE"
+     */
+    async #modifySubscription(method: "PUT" | "DELETE"): Promise<this> {
+        if (!this.client.isAuthorized()) {
+            throw new iFunnyError(this.client, {
+                error: IFUNNY_ERRORS.UNAUTHORIZED,
+                error_description:
+                    "Requested operation is unavailable for guests",
+                status: 400,
+            });
+        }
 
-		if (this.id === this.client.payload.id) {
-			return this;
-		}
+        if (this.id === this.client.payload.id) {
+            return this;
+        }
 
-		await this.client.instance.request({
-			method,
-			url: Endpoints.subscribers(this.id),
-		});
+        await this.client.instance.request({
+            method,
+            url: Endpoints.subscribers(this.id),
+        });
 
-		return this;
-	}
+        return this;
+    }
 
-	/**
-	 * Subscribe to the User
-	 */
-	public async subscribe(): Promise<void> {
-		await this.#modifySubscription("PUT");
-	}
+    /**
+     * Subscribe to the User
+     */
+    public async subscribe(): Promise<void> {
+        await this.#modifySubscription("PUT");
+    }
 
-	/**
-	 * Unsubscribe from the User
-	 */
-	public async unsubscribe(): Promise<void> {
-		this.#modifySubscription("DELETE");
-	}
+    /**
+     * Unsubscribe from the User
+     */
+    public async unsubscribe(): Promise<void> {
+        this.#modifySubscription("DELETE");
+    }
 
-	/**
-	 * Get the User's timeline object
-	 * @returns Feed
-	 */
-	public get timeline(): Feed {
-		return (this.#timeline ??= new Feed(
-			this.client,
-			Endpoints.userTimeline(this.id)
-		));
-	}
+    /**
+     * Get the User's timeline object
+     * @returns Feed
+     */
+    public get timeline(): Feed {
+        return (this.#timeline ??= new Feed(
+            this.client,
+            Endpoints.userTimeline(this.id),
+        ));
+    }
 }
 
 export default User;

--- a/src/structures/mod.ts
+++ b/src/structures/mod.ts
@@ -1,0 +1,17 @@
+export * as Ban from "./Ban";
+export * as BanSmall from "./BanSmall";
+export * as Base from "./Base";
+export * as BaseComment from "./BaseComment";
+export * as BaseContent from "./BaseContent";
+export * as BaseFeed from "./BaseFeed";
+export * as BaseUser from "./BaseUser";
+export * as Cache from "./Cache";
+export * as Comment from "./Comment";
+export * as Content from "./Content";
+export * as Creator from "./Creator";
+export * as Feed from "./Feed";
+export * as MemeExperience from "./MemeExperience";
+export * as New from "./News";
+export * as SimpleUser from "./SimpleUser";
+export * as Thumbnail from "./Thumbnail";
+export * as User from "./User";

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -1,4 +1,3 @@
-import { AxiosHeaders } from "axios";
 import { BasicAuthConfig, BasicAuthLength } from "./Types";
 
 // * User Agent
@@ -14,9 +13,9 @@ export const DefaultClientId: string = "MsOIJ39Q28";
 export const DefaultClientSecret: string = "PTDc3H8a)Vi=UYap";
 export const DefaultBasicTokenLength: BasicAuthLength = 112;
 export const DefaultBasicAuthConfig: BasicAuthConfig = {
-	clientId: DefaultClientId,
-	clientSecret: DefaultClientSecret,
-	length: DefaultBasicTokenLength,
+    clientId: DefaultClientId,
+    clientSecret: DefaultClientSecret,
+    length: DefaultBasicTokenLength,
 };
 
 // Device Agent (Android)
@@ -37,10 +36,10 @@ export const DefaultAcceptLang = "en";
 export const DefaultAcceptEncoding = "gzip";
 export const DefaultApplicationState = 1;
 
-export const DefaultHeaders: AxiosHeaders = new AxiosHeaders({
-	"ifunny-project-id": iFunnyProjectId,
-	accept: DefaultAccept,
-	"accept-encoding": DefaultAcceptEncoding,
-	"accept-language": DefaultAcceptLang,
-	"user-agent": DefaultUserAgent,
-});
+export const DefaultHeaders = {
+    "ifunny-project-id": iFunnyProjectId,
+    accept: DefaultAccept,
+    "accept-encoding": DefaultAcceptEncoding,
+    "accept-language": DefaultAcceptLang,
+    "user-agent": DefaultUserAgent,
+};

--- a/src/utils/Types.ts
+++ b/src/utils/Types.ts
@@ -22,10 +22,10 @@ export type JSONValue = SafePrimitive | JSONArray | JSONObject;
  * An object that can contain any JSON value, as well as nested JSON objects and arrays.
  */
 export interface JSONObject {
-	/**
-	 * An index signature that allows any string key and either a JSON value, a JSON object, or an array of JSON objects.
-	 */
-	[key: string]: JSONValue | JSONObject | JSONObject[];
+    /**
+     * An index signature that allows any string key and either a JSON value, a JSON object, or an array of JSON objects.
+     */
+    [key: string]: JSONValue | JSONObject | JSONObject[];
 }
 
 /**
@@ -35,10 +35,10 @@ export interface JSONObject {
  * @template B - The type to select if T is false.
  */
 export type If<T extends boolean, A, B = null> = T extends true
-	? A
-	: T extends false
-	? B
-	: A | B;
+    ? A
+    : T extends false
+      ? B
+      : A | B;
 
 export type BasicAuthLength = 112 | 156;
 
@@ -46,18 +46,18 @@ export type BasicAuthLength = 112 | 156;
  * Configuration options for basic authentication.
  */
 export type BasicAuthConfig = {
-	/**
-	 * The client ID to use for authentication.
-	 */
-	clientId: string;
-	/**
-	 * The client secret to use for authentication.
-	 */
-	clientSecret: string;
-	/**
-	 * The length of the authentication token to generate (112 or 156)
-	 */
-	length: BasicAuthLength;
+    /**
+     * The client ID to use for authentication.
+     */
+    clientId: string;
+    /**
+     * The client secret to use for authentication.
+     */
+    clientSecret: string;
+    /**
+     * The length of the authentication token to generate (112 or 156)
+     */
+    length: BasicAuthLength;
 };
 
 /**

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -1,229 +1,229 @@
 import { DefaultBasicAuthConfig } from "./Constants";
-import axios, {
-	AxiosError,
-	AxiosRequestConfig,
-	AxiosResponse,
-} from "axios";
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import crypto from "crypto";
 import type { BasicAuthConfig } from "./Types";
 import type { Client } from "../client/Client";
 import type { PaginateConfig } from "../structures/BaseFeed";
 import type {
-	RESTAPIErrorResponse,
-	RESTAPIItems,
-	RESTAPISuccessResponse,
+    RESTAPIErrorResponse,
+    RESTAPIItems,
+    RESTAPISuccessResponse,
 } from "@ifunny/ifunny-api-types";
 
 /**
  * Utility class used by the Client
  */
 export class Util {
-	/**
-	 * Private member for the Client instance
-	 */
-	readonly #client: Client;
+    /**
+     * Private member for the Client instance
+     */
+    readonly #client: Client;
 
-	/**
-	 * @param client Client attached to the Utility class
-	 */
-	public constructor(client: Client) {
-		this.#client = client;
-	}
+    /**
+     * @param client Client attached to the Utility class
+     */
+    public constructor(client: Client) {
+        this.#client = client;
+    }
 
-	/**
-	 * Asserts a claim to be true
-	 * @param claim The claim to check
-	 * @param error The message to send if the claim evaluted to false
-	 * @internal
-	 */
-	assert(claim: boolean, error: Error | string): claim is true {
-		if (!claim) {
-			if (typeof error === "string") {
-				throw new Error(error);
-			} else if (error instanceof Error) {
-				throw error;
-			}
-		}
-		return true;
-	}
+    /**
+     * Asserts a claim to be true
+     * @param claim The claim to check
+     * @param error The message to send if the claim evaluted to false
+     * @internal
+     */
+    assert(claim: boolean, error: Error | string): claim is true {
+        if (!claim) {
+            if (typeof error === "string") {
+                throw new Error(error);
+            } else if (error instanceof Error) {
+                throw error;
+            }
+        }
+        return true;
+    }
 
-	/**
-	 * Generates a basic token
-	 * @param opts Options to create the token with
-	 * @param opts.clientId The client id to use for the token
-	 * @param opts.clientSecret The client secret to use for the token
-	 * @param opts.length The length of the token to create
-	 * @returns A basic auth token
-	 */
-	public createBasicAuth(opts?: BasicAuthConfig) {
-		const { length, clientId, clientSecret } = Object.assign(
-			DefaultBasicAuthConfig,
-			opts
-		);
+    /**
+     * Generates a basic token
+     * @param opts Options to create the token with
+     * @param opts.clientId The client id to use for the token
+     * @param opts.clientSecret The client secret to use for the token
+     * @param opts.length The length of the token to create
+     * @returns A basic auth token
+     */
+    public createBasicAuth(opts?: BasicAuthConfig) {
+        const { length, clientId, clientSecret } = Object.assign(
+            DefaultBasicAuthConfig,
+            opts,
+        );
 
-		const uuid = crypto.randomUUID().replace(/\-/g, "");
-		let hex: string;
-		switch (length) {
-			case 112:
-				hex = uuid.toUpperCase();
-				break;
-			case 156:
-				hex = crypto
-					.createHash("sha256")
-					.update(uuid)
-					.digest("hex")
-					.toUpperCase();
-				break;
-			default:
-				throw TypeError("Invalid token length. Expected 112 | 156");
-		}
+        const uuid = crypto.randomUUID().replace(/-/g, "");
+        let hex: string;
+        switch (length) {
+            case 112:
+                hex = uuid.toUpperCase();
+                break;
+            case 156:
+                hex = crypto
+                    .createHash("sha256")
+                    .update(uuid)
+                    .digest("hex")
+                    .toUpperCase();
+                break;
+            default:
+                throw TypeError("Invalid token length. Expected 112 | 156");
+        }
 
-		const a = hex + `_${clientId}:`;
-		const b = hex + `:${clientId}:${clientSecret}`;
-		const c = crypto.createHash("sha1").update(b).digest("hex");
+        const a = hex + `_${clientId}:`;
+        const b = hex + `:${clientId}:${clientSecret}`;
+        const c = crypto.createHash("sha1").update(b).digest("hex");
 
-		return Buffer.from(a + c).toString("base64");
-	}
+        return Buffer.from(a + c).toString("base64");
+    }
 
-	/**
-	 * Validates that something is an Axios Error
-	 * @param item Item to validate
-	 * @internal
-	 */
-	isAxiosError(item: unknown): item is AxiosError & {
-		response: AxiosResponse<unknown>;
-	} {
-		if (!axios.isAxiosError(item) || !item.response) return false;
-		return true;
-	}
+    /**
+     * Validates that something is an Axios Error
+     * @param item Item to validate
+     * @internal
+     */
+    isAxiosError(item: unknown): item is AxiosError & {
+        response: AxiosResponse<unknown>;
+    } {
+        if (!axios.isAxiosError(item) || !item.response) return false;
+        return true;
+    }
 
-	/**
-	 * Validates that an object matches the RESTAPIErrorResponse schema
-	 * @param error Error to validate
-	 * @returns error is RESTAPIErrorResponse
-	 * @internal
-	 */
-	isAPIError(error: unknown): error is RESTAPIErrorResponse {
-		if (!this.hasProperty(error, "error")) return false;
-		if (!this.hasProperty(error, "error_description")) return false;
-		if (!this.hasProperty(error, "status")) return false;
-		if (typeof error.error !== "string") return false;
-		if (typeof error.error_description !== "string") return false;
-		if (typeof error.status !== "number") return false;
-		return true;
-	}
+    /**
+     * Validates that an object matches the RESTAPIErrorResponse schema
+     * @param error Error to validate
+     * @returns error is RESTAPIErrorResponse
+     * @internal
+     */
+    isAPIError(error: unknown): error is RESTAPIErrorResponse {
+        if (!this.hasProperty(error, "error")) return false;
+        if (!this.hasProperty(error, "error_description")) return false;
+        if (!this.hasProperty(error, "status")) return false;
+        if (typeof error.error !== "string") return false;
+        if (typeof error.error_description !== "string") return false;
+        if (typeof error.status !== "number") return false;
+        return true;
+    }
 
-	/**
-	 * Certain requests have a header for 'if-modified-since' which uses the current timestamp
-	 * @param date Custom date
-	 * @returns GMT timestamp of the date
-	 * @internal
-	 */
-	ifModifiedSince(date?: Date): string {
-		date ??= new Date();
-		return date.toUTCString();
-	}
+    /**
+     * Certain requests have a header for 'if-modified-since' which uses the current timestamp
+     * @param date Custom date
+     * @returns GMT timestamp of the date
+     * @internal
+     */
+    ifModifiedSince(date?: Date): string {
+        date ??= new Date();
+        return date.toUTCString();
+    }
 
-	/**
-	 * Paginates through items in a REST API endpoint.
-	 * @param url The url to get
-	 * @param key The key to get the array of values from
-	 * @param params The params to pass to the url
-	 * @param full Whether to yield the full data or just the items (default false)
-	 * @yields The value of the key
-	 * @internal
-	 */
-	async *paginate<T extends unknown>(
-		url: string,
-		key: string,
-		params?: PaginateConfig,
-		full: boolean = false
-	): AsyncGenerator<T> {
-		// Verify config
-		if (!url) throw new Error("paginate: url is required");
-		if (!key) throw new Error("paginate: key is required");
+    /**
+     * Paginates through items in a REST API endpoint.
+     * @param url The url to get
+     * @param key The key to get the array of values from
+     * @param params The params to pass to the url
+     * @param full Whether to yield the full data or just the items (default false)
+     * @yields The value of the key
+     * @internal
+     */
+    async *paginate<T extends unknown>(
+        url: string,
+        key: string,
+        params?: PaginateConfig,
+        full: boolean = false,
+    ): AsyncGenerator<T> {
+        // Verify config
+        if (!url) throw new Error("paginate: url is required");
+        if (!key) throw new Error("paginate: key is required");
 
-		// Set method
-		let method: "GET" | "POST" = "GET";
-		if (url.toLowerCase() === "feeds/collective") {
-			method = "POST";
-		}
+        // Set method
+        let method: "GET" | "POST" = "GET";
+        if (url.toLowerCase() === "feeds/collective") {
+            method = "POST";
+        }
 
-		let hasNext: boolean;
-		const data = new URLSearchParams();
+        let hasNext: boolean;
+        const data = new URLSearchParams();
 
-		// Set params
-		for (const key in params) {
-			data.set(key, `${params[key as keyof PaginateConfig]}`);
-		}
+        // Set params
+        for (const key in params) {
+            data.set(key, `${params[key as keyof PaginateConfig]}`);
+        }
 
-		// Request config
-		const config: AxiosRequestConfig =
-			method === "GET" ? { method, url, params: data } : { method, url, data };
+        // Request config
+        const config: AxiosRequestConfig =
+            method === "GET"
+                ? { method, url, params: data }
+                : { method, url, data };
 
-		do {
-			interface Items {
-				[key: string]: RESTAPIItems<T>;
-			}
-			const response = await this.#client.instance.request<
-				RESTAPISuccessResponse<Items>
-			>(config);
+        do {
+            interface Items {
+                [key: string]: RESTAPIItems<T>;
+            }
+            const response =
+                await this.#client.instance.request<
+                    RESTAPISuccessResponse<Items>
+                >(config);
 
-			const items = response.data?.data?.[key]?.items;
-			if (!Array.isArray(items)) throw new Error(`paginate: items is not an array`);
+            const items = response.data?.data?.[key]?.items;
+            if (!Array.isArray(items))
+                throw new Error(`paginate: items is not an array`);
 
-			// Set next param
-			hasNext = response.data?.data?.[key]?.paging?.hasNext ?? false;
+            // Set next param
+            hasNext = response.data?.data?.[key]?.paging?.hasNext ?? false;
 
-			if (hasNext) {
-				data.set("next", response.data.data[key].paging.cursors.next!);
-			}
+            if (hasNext) {
+                data.set("next", response.data.data[key].paging.cursors.next!);
+            }
 
-			// Yield the full data if wanted
-			if (full) {
-				//console.log("yield full");
-				yield response.data as Awaited<T>;
-				continue;
-			}
+            // Yield the full data if wanted
+            if (full) {
+                //console.log("yield full");
+                yield response.data as Awaited<T>;
+                continue;
+            }
 
-			for (const item of items) {
-				//console.log("yield item");
-				yield item;
-			}
-		} while (hasNext);
-	}
+            for (const item of items) {
+                //console.log("yield item");
+                yield item;
+            }
+        } while (hasNext);
+    }
 
-	/**
-	 * Sleeps the program for the specified amount of milliseconds
-	 * @param ms The number of milliseconds to wait
-	 * @returns A promise that resolves after the given amount of time
-	 */
-	public async sleep(ms: number): Promise<void> {
-		return new Promise((resolve) => setTimeout(resolve, ms));
-	}
+    /**
+     * Sleeps the program for the specified amount of milliseconds
+     * @param ms The number of milliseconds to wait
+     * @returns A promise that resolves after the given amount of time
+     */
+    public async sleep(ms: number): Promise<void> {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    }
 
-	/**
-	 * Converts data into a json like string
-	 * @param data Data to convert to JSON
-	 * @returns JSON data
-	 */
-	public toJSON(data: unknown): string {
-		return JSON.stringify(data, null, 2);
-	}
+    /**
+     * Converts data into a json like string
+     * @param data Data to convert to JSON
+     * @returns JSON data
+     */
+    public toJSON(data: unknown): string {
+        return JSON.stringify(data, null, 2);
+    }
 
-	/**
-	 * Type guard to validate key existance on an object
-	 * @param obj Object to check key for
-	 * @param prop Property to check is defined
-	 * @returns `obj` has property `prop`
-	 * @internal
-	 */
-	hasProperty<Obj, Prop extends string>(
-		obj: Obj,
-		prop: Prop
-	): obj is Obj & Record<Prop, unknown> {
-		return Object.prototype.hasOwnProperty.call(obj, prop);
-	}
+    /**
+     * Type guard to validate key existance on an object
+     * @param obj Object to check key for
+     * @param prop Property to check is defined
+     * @returns `obj` has property `prop`
+     * @internal
+     */
+    hasProperty<Obj, Prop extends string>(
+        obj: Obj,
+        prop: Prop,
+    ): obj is Obj & Record<Prop, unknown> {
+        return Object.prototype.hasOwnProperty.call(obj, prop);
+    }
 }
 
 export default Util;

--- a/src/utils/mod.ts
+++ b/src/utils/mod.ts
@@ -1,0 +1,3 @@
+export { Util } from "./Util";
+export * as Types from "./Types";
+export * as Constants from "./Constants";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "noEmit": false,
         "emitDeclarationOnly": true,
         "declaration": true,
+        "declarationMap": true,
         "strict": true,
         "downlevelIteration": true,
         "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compileOnSave": true,
     "compilerOptions": {
-        "outDir": "./types",
-        "declarationDir": "./dist",
+        "outDir": "./dist",
+        "declarationDir": "./types",
         "rootDir": "./src",
         "baseUrl": "./",
         "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,31 @@
 {
-	"compileOnSave": true,
-	"compilerOptions": {
-		"declaration": true,
-		"declarationDir": "types",
-		"declarationMap": true,
-		"forceConsistentCasingInFileNames": true,
-		"module": "CommonJS",
-		"noImplicitOverride": true,
-		"noUnusedLocals": true,
-		"outDir": "dist",
-		"removeComments": false,
-		"sourceMap": true,
-		"strict": true,
-		"target": "ES2020",
-		"pretty": true,
-		"allowSyntheticDefaultImports": true,
-		"esModuleInterop": true,
-		"stripInternal": true,
-		"skipDefaultLibCheck": true,
-		"skipLibCheck": true
-	},
-	"include": ["src/**/*.ts"]
+    "compileOnSave": true,
+    "compilerOptions": {
+        "outDir": "./types",
+        "declarationDir": "./dist",
+        "rootDir": "./src",
+        "baseUrl": "./",
+        "paths": {
+            "@/*": ["src/*"]
+        },
+        "lib": ["ESNext"],
+        "module": "esnext",
+        "target": "esnext",
+        "moduleResolution": "bundler",
+        "moduleDetection": "force",
+        "allowImportingTsExtensions": true,
+        "removeComments": false,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "declaration": true,
+        "strict": true,
+        "downlevelIteration": true,
+        "skipLibCheck": true,
+        "jsx": "react-jsx",
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true,
+        "allowJs": true,
+        "types": ["bun-types"]
+    },
+    "include": ["src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compileOnSave": true,
     "compilerOptions": {
         "outDir": "./dist",
-        "declarationDir": "./types",
+        "declarationDir": "./dist",
         "rootDir": "./src",
         "baseUrl": "./",
         "paths": {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": ["./src/"],
+    "entryPointStrategy": "expand",
+    "out": "./docs",
+    "lang": "en",
+    "useTsLinkResolution": true
+}


### PR DESCRIPTION
- **chore(gitignore): add docs/* to gitignore**
- **chore(gitignore): add docs/ to gitignore**
- **feat: add prettier config**
- **chore(devenv): switch to unstable nixpkgs**
- **chore(devenv): add nix and bun and switch to nodejs_25**
- **build(bun): configure tooling + update packages and scripts**
- **build(npm): add format script**
- **style(formatting): run prettier**
- **refactor(client): refactor client header types and format**
- **style(formatting): run prettier and convert @alias to @link**
- **refactor(client): convert headers to object literals**
- **chore(npm): add mod.ts files for module exporting**
- **refactor(typescript): refactor exports to include everything and separate into modules**
- **build(typescript): allow package to be installed via git**
- **refactor(typescript): move types to dist**
- **build(typescript): add declarationMap**
